### PR TITLE
Port to Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ PREFIX=/usr
 
 TESTSUITE:=tests/baseclass.py
 
+PYTHON?=python
+
 all:
 	$(MAKE) -C po
 
@@ -27,7 +29,7 @@ check:
 
 test:
 	@echo "*** Running unittests ***"
-	PYTHONPATH=. python $(TESTSUITE) -v
+	PYTHONPATH=. $(PYTHON) $(TESTSUITE) -v
 
 coverage:
 	@which coverage || (echo "*** Please install python-coverage ***"; exit 2)
@@ -38,10 +40,10 @@ coverage:
 clean:
 	-rm *.tar.gz pykickstart/*.pyc pykickstart/*/*.pyc tests/*.pyc tests/*/*.pyc docs/kickstart-docs.txt docs/programmers-guide
 	$(MAKE) -C po clean
-	python setup.py -q clean --all
+	$(PYTHON) setup.py -q clean --all
 
 install:
-	python setup.py install --root=$(DESTDIR)
+	$(PYTHON) setup.py install --root=$(DESTDIR)
 	$(MAKE) -C po install
 
 tag:
@@ -65,7 +67,7 @@ local: docs po-pull
 	@rm -rf $(PKGNAME)-$(VERSION).tar.gz
 	@rm -rf /tmp/$(PKGNAME)-$(VERSION) /tmp/$(PKGNAME)
 	@dir=$$PWD; cp -a $$dir /tmp/$(PKGNAME)-$(VERSION)
-	@cd /tmp/$(PKGNAME)-$(VERSION) ; python setup.py -q sdist
+	@cd /tmp/$(PKGNAME)-$(VERSION) ; $(PYTHON) setup.py -q sdist
 	@cp /tmp/$(PKGNAME)-$(VERSION)/dist/$(PKGNAME)-$(VERSION).tar.gz .
 	@rm -rf /tmp/$(PKGNAME)-$(VERSION)
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tag:
 	git tag -a -m "Tag as $(TAG)" -f $(TAG)
 	@echo "Tagged as $(TAG)"
 
-archive: test tag docs
+archive: check test tag docs
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(TAG) > $(PKGNAME)-$(VERSION).tar
 	mkdir -p $(PKGNAME)-$(VERSION)
 	cp -r po $(PKGNAME)-$(VERSION)/po/

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tag:
 	git tag -a -m "Tag as $(TAG)" -f $(TAG)
 	@echo "Tagged as $(TAG)"
 
-archive: check test tag docs
+archive: test tag docs
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(TAG) > $(PKGNAME)-$(VERSION).tar
 	mkdir -p $(PKGNAME)-$(VERSION)
 	cp -r po $(PKGNAME)-$(VERSION)/po/

--- a/README
+++ b/README
@@ -1,3 +1,3 @@
-pykickstart is a python library consisting of a data representation of
-kickstart files, a parser to read file into that representation, and a
-writer to generate kickstart files.
+Pykickstart is a Python 2 and Python 3 library consisting of a data
+representation of kickstart files, a parser to read file into that
+representation, and a writer to generate kickstart files.

--- a/pykickstart.spec
+++ b/pykickstart.spec
@@ -15,11 +15,10 @@ Group: System Environment/Libraries
 BuildArch: noarch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: python-devel, gettext, python-setuptools
-BuildRequires: python-urlgrabber
 %if ! 0%{?rhel}
 BuildRequires: transifex-client
 %endif
-Requires: python, python-urlgrabber
+Requires: python
 
 %description
 The pykickstart package is a python library for manipulating kickstart

--- a/pykickstart.spec
+++ b/pykickstart.spec
@@ -1,58 +1,130 @@
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
-Summary:  A python library for manipulating kickstart files
-Name: pykickstart
-Url: http://fedoraproject.org/wiki/pykickstart
-Version: 1.99.65
-Release: 1%{?dist}
+Name:           pykickstart
+Version:        1.99.66
+Release:        1%{?dist}
+License:        GPLv2
+Group:          System Environment/Libraries
+Summary:        Python utilities for manipulating kickstart files.
+Url:            http://fedoraproject.org/wiki/%{name}
 # This is a Red Hat maintained package which is specific to
 # our distribution.  Thus the source is only available from
 # within this srpm.
-Source0: %{name}-%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 
-License: GPLv2
-Group: System Environment/Libraries
-BuildArch: noarch
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildRequires: python-devel, gettext, python-setuptools
+BuildArch:      noarch
+
+BuildRequires:  gettext
+BuildRequires:  python-devel
+BuildRequires:  python-setuptools
+BuildRequires:  python-six
+
 %if ! 0%{?rhel}
-BuildRequires: transifex-client
+BuildRequires:  transifex-client
 %endif
-Requires: python
+
+# Deps for python3-pykickstart
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-six
 
 %description
-The pykickstart package is a python library for manipulating kickstart
-files.
+Python utilities for manipulating kickstart files. The Python 2 and 3 libraries
+can be found in the packages python-pykickstart and python3-pykickstart,
+respectively.
+
+
+# Python 2 library
+%package -n python-pykickstart
+Summary:        Python 2 library for manipulating kickstart files.
+Requires:       pykickstart-translations
+Requires:       python-six
+
+%description -n python-pykickstart
+Python 2 library for manipulating kickstart files. The binaries are found in
+the pykickstart package.
+
+
+# Python 3 library
+%package -n python3-pykickstart
+Summary:        Python 3 library for manipulating kickstart files.
+Requires:       pykickstart-translations
+Requires:       python3-pykickstart
+Requires:       python3-six
+
+%description -n python3-pykickstart
+Python 3 library for manipulating kickstart files. The binaries are found in
+the pykickstart package.
+
+
+# Translations
+%package translations
+Summary:        Python 3 library for manipulating kickstart files.
+
+%description translations
+Translations for the pykickstart library (both Python 2 and 3 versions).
+
 
 %prep
 %setup -q
 
+rm -rf %{py3dir}
+mkdir %{py3dir}
+cp -a . %{py3dir}
+
+
 %build
 make
+
+pushd %{py3dir}
+PYTHON=%{__python3} make
+popd
+
 
 %install
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} install
 %find_lang %{name}
 
-%clean
-rm -rf %{buildroot}
+pushd %{py3dir}
+PYTHON=%{__python3} make DESTDIR=%{buildroot} install
+popd
+
 
 %check
 make test
 
-%files -f %{name}.lang
-%defattr(-,root,root,-)
-%doc README COPYING docs/programmers-guide
-%doc docs/kickstart-docs.txt
-%{python_sitelib}/*
+pushd %{py3dir}
+PYTHON=%{__python3} make test
+popd
+
+
+%files
+%doc README COPYING
 %{_bindir}/ksvalidator
 %{_bindir}/ksflatten
 %{_bindir}/ksverdiff
 %{_bindir}/ksshell
 %{_mandir}/man1/*
 
+%files -n python-pykickstart
+%doc README COPYING docs/programmers-guide
+%doc docs/kickstart-docs.txt
+%{python_sitelib}/*
+
+%files -n python3-pykickstart
+%doc README COPYING docs/programmers-guide
+%doc docs/kickstart-docs.txt
+%{python3_sitelib}/*
+
+%files translations -f %{name}.lang
+
+
 %changelog
+* Thu Jan 15 2015 Tomas Radej <tradej@redhat.com> - 1.99.66-1
+- Ported to Python 3
+- Split to subpackages - binaries, Python 2 and 3 libraries, translations
+
 * Mon Dec 15 2014 Chris Lumens <clumens@redhat.com> - 1.99.65-1
 - Add support for setting user account ssh key (bcl)
 - Add = to the output for various network options (#1171926). (clumens)

--- a/pykickstart.spec
+++ b/pykickstart.spec
@@ -3,7 +3,7 @@
 Name:           pykickstart
 Version:        1.99.66
 Release:        1%{?dist}
-License:        GPLv2
+License:        GPLv2 and MIT
 Group:          System Environment/Libraries
 Summary:        Python utilities for manipulating kickstart files.
 Url:            http://fedoraproject.org/wiki/%{name}

--- a/pykickstart/__init__.py
+++ b/pykickstart/__init__.py
@@ -3,7 +3,7 @@ import gettext
 import six
 
 def _(x):
-    if not x: # Workaround for gettext behaviour on empty strings
+    if x == '': # Workaround for gettext behaviour on empty strings
         return ''
 
     result = gettext.ldgettext('pykickstart', x)

--- a/pykickstart/__init__.py
+++ b/pykickstart/__init__.py
@@ -1,0 +1,14 @@
+
+import gettext
+import six
+
+if six.PY3:
+    import sys
+    def _(x):
+        result = gettext.ldgettext('pykickstart', x)
+        if isinstance(result, bytes):
+            return result.decode(sys.getdefaultencoding())
+        else:
+            return result
+else:
+    _ = lambda x: gettext.ldgettext("pykickstart", x)

--- a/pykickstart/__init__.py
+++ b/pykickstart/__init__.py
@@ -2,13 +2,15 @@
 import gettext
 import six
 
-if six.PY3:
-    import sys
-    def _(x):
-        result = gettext.ldgettext('pykickstart', x)
+def _(x):
+    if not x: # Workaround for gettext behaviour on empty strings
+        return ''
+
+    result = gettext.ldgettext('pykickstart', x)
+
+    if six.PY3: # In Python 3, gettext returns bytes sometimes
+        import sys
         if isinstance(result, bytes):
-            return result.decode(sys.getdefaultencoding())
-        else:
-            return result
-else:
-    _ = lambda x: gettext.ldgettext("pykickstart", x)
+            result = result.decode(sys.getdefaultencoding())
+
+    return result

--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -40,7 +40,7 @@ This module exports several important base classes:
 """
 import gettext
 gettext.textdomain("pykickstart")
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 import six
 import types

--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -43,7 +43,6 @@ gettext.textdomain("pykickstart")
 from pykickstart import _
 
 import six
-import types
 import warnings
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.ko import KickstartObject

--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -42,6 +42,7 @@ import gettext
 gettext.textdomain("pykickstart")
 _ = lambda x: gettext.ldgettext("pykickstart", x)
 
+import six
 import types
 import warnings
 from pykickstart.errors import KickstartParseError, formatErrorMsg
@@ -100,7 +101,7 @@ class KickstartCommand(KickstartObject):
         # members from the kwargs list before we start processing it.  This
         # ensures that subclasses don't continue to recognize arguments that
         # were removed.
-        for arg in filter(kwargs.has_key, self.removedKeywords):
+        for arg in (kw for kw in self.removedKeywords if kw in kwargs):
             kwargs.pop(arg)
 
     def __call__(self, *args, **kwargs):
@@ -283,13 +284,13 @@ class BaseHandler(KickstartObject):
         for prio in lst:
             for obj in self._writeOrder[prio]:
                 obj_str = obj.__str__()
-                if type(obj_str) == types.UnicodeType:
+                if type(obj_str) is six.text_type and not six.PY3:
                     obj_str = obj_str.encode("utf-8")
                 retval += obj_str
 
         for script in self.scripts:
             script_str = script.__str__()
-            if type(script_str) == types.UnicodeType:
+            if type(script_str) is six.text_type and not six.PY3:
                 script_str = script_str.encode("utf-8")
             retval += script_str
 
@@ -323,9 +324,13 @@ class BaseHandler(KickstartObject):
         # way for clients to access the command objects.  We also need to strip
         # off the version part from the front of the name.
         if cmdObj.__class__.__name__.find("_") != -1:
-            name = unicode(cmdObj.__class__.__name__.split("_", 1)[1])
+            name = cmdObj.__class__.__name__.split("_", 1)[1]
+            if not six.PY3:
+                name = unicode(name)
         else:
-            name = unicode(cmdObj.__class__.__name__).lower()
+            name = cmdObj.__class__.__name__.lower()
+            if not six.PY3:
+                name = unicode(name)
 
         setattr(self, name.lower(), cmdObj)
 

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartParseError, KickstartValueError, formatE
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_AutoPart(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -22,7 +22,6 @@ from pykickstart.constants import AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, AUTOPA
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_AutoPart(KickstartCommand):

--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Bootloader(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Bootloader(KickstartCommand):

--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -24,7 +24,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F17_BTRFSData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -22,7 +22,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/cdrom.py
+++ b/pykickstart/commands/cdrom.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Cdrom(KickstartCommand):

--- a/pykickstart/commands/cdrom.py
+++ b/pykickstart/commands/cdrom.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Cdrom(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/device.py
+++ b/pykickstart/commands/device.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/device.py
+++ b/pykickstart/commands/device.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F8_DeviceData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/displaymode.py
+++ b/pykickstart/commands/displaymode.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_DisplayMode(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/displaymode.py
+++ b/pykickstart/commands/displaymode.py
@@ -22,7 +22,6 @@ from pykickstart.constants import DISPLAY_MODE_CMDLINE, DISPLAY_MODE_GRAPHICAL, 
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_DisplayMode(KickstartCommand):

--- a/pykickstart/commands/dmraid.py
+++ b/pykickstart/commands/dmraid.py
@@ -21,7 +21,6 @@
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/dmraid.py
+++ b/pykickstart/commands/dmraid.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_DmRaidData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/driverdisk.py
+++ b/pykickstart/commands/driverdisk.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_DriverDiskData(BaseData):

--- a/pykickstart/commands/driverdisk.py
+++ b/pykickstart/commands/driverdisk.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_DriverDiskData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/eula.py
+++ b/pykickstart/commands/eula.py
@@ -22,7 +22,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class F20_Eula(KickstartCommand):

--- a/pykickstart/commands/eula.py
+++ b/pykickstart/commands/eula.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F20_Eula(KickstartCommand):
     """The 'eula' kickstart command"""

--- a/pykickstart/commands/fcoe.py
+++ b/pykickstart/commands/fcoe.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F12_FcoeData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/fcoe.py
+++ b/pykickstart/commands/fcoe.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/firewall.py
+++ b/pykickstart/commands/firewall.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Firewall(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/firewall.py
+++ b/pykickstart/commands/firewall.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Firewall(KickstartCommand):

--- a/pykickstart/commands/group.py
+++ b/pykickstart/commands/group.py
@@ -20,7 +20,6 @@
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/group.py
+++ b/pykickstart/commands/group.py
@@ -22,7 +22,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F12_GroupData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/harddrive.py
+++ b/pykickstart/commands/harddrive.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_HardDrive(KickstartCommand):

--- a/pykickstart/commands/harddrive.py
+++ b/pykickstart/commands/harddrive.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_HardDrive(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/ignoredisk.py
+++ b/pykickstart/commands/ignoredisk.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_IgnoreDisk(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/ignoredisk.py
+++ b/pykickstart/commands/ignoredisk.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_IgnoreDisk(KickstartCommand):

--- a/pykickstart/commands/interactive.py
+++ b/pykickstart/commands/interactive.py
@@ -21,7 +21,6 @@ from pykickstart.base import DeprecatedCommand, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Interactive(KickstartCommand):

--- a/pykickstart/commands/interactive.py
+++ b/pykickstart/commands/interactive.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Interactive(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/iscsi.py
+++ b/pykickstart/commands/iscsi.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_IscsiData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/iscsi.py
+++ b/pykickstart/commands/iscsi.py
@@ -22,7 +22,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC6_IscsiData(BaseData):

--- a/pykickstart/commands/iscsiname.py
+++ b/pykickstart/commands/iscsiname.py
@@ -22,7 +22,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC6_IscsiName(KickstartCommand):

--- a/pykickstart/commands/iscsiname.py
+++ b/pykickstart/commands/iscsiname.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_IscsiName(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/key.py
+++ b/pykickstart/commands/key.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class RHEL5_Key(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/key.py
+++ b/pykickstart/commands/key.py
@@ -22,7 +22,6 @@ from pykickstart.constants import KS_INSTKEY_SKIP
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class RHEL5_Key(KickstartCommand):

--- a/pykickstart/commands/keyboard.py
+++ b/pykickstart/commands/keyboard.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Keyboard(KickstartCommand):

--- a/pykickstart/commands/keyboard.py
+++ b/pykickstart/commands/keyboard.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Keyboard(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/lang.py
+++ b/pykickstart/commands/lang.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Lang(KickstartCommand):

--- a/pykickstart/commands/lang.py
+++ b/pykickstart/commands/lang.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Lang(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/lilocheck.py
+++ b/pykickstart/commands/lilocheck.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_LiloCheck(KickstartCommand):

--- a/pykickstart/commands/lilocheck.py
+++ b/pykickstart/commands/lilocheck.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_LiloCheck(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/liveimg.py
+++ b/pykickstart/commands/liveimg.py
@@ -21,7 +21,7 @@ from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F19_Liveimg(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/liveimg.py
+++ b/pykickstart/commands/liveimg.py
@@ -20,9 +20,6 @@
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
-from pykickstart import _
-
 class F19_Liveimg(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs

--- a/pykickstart/commands/logging.py
+++ b/pykickstart/commands/logging.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC6_Logging(KickstartCommand):

--- a/pykickstart/commands/logging.py
+++ b/pykickstart/commands/logging.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_Logging(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_LogVolData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -67,7 +67,7 @@ class FC3_LogVolData(BaseData):
             retval += " --percent=%d" % self.percent
         if self.recommended:
             retval += " --recommended"
-        if self.size > 0:
+        if self.size is not None and self.size > 0:
             retval += " --size=%d" % self.size
         if self.preexist:
             retval += " --useexisting"

--- a/pykickstart/commands/mediacheck.py
+++ b/pykickstart/commands/mediacheck.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC4_MediaCheck(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/mediacheck.py
+++ b/pykickstart/commands/mediacheck.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC4_MediaCheck(KickstartCommand):

--- a/pykickstart/commands/monitor.py
+++ b/pykickstart/commands/monitor.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Monitor(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/monitor.py
+++ b/pykickstart/commands/monitor.py
@@ -21,7 +21,6 @@ from pykickstart.base import DeprecatedCommand, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Monitor(KickstartCommand):

--- a/pykickstart/commands/mouse.py
+++ b/pykickstart/commands/mouse.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class RHEL3_Mouse(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/mouse.py
+++ b/pykickstart/commands/mouse.py
@@ -21,7 +21,6 @@ from pykickstart.base import DeprecatedCommand, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class RHEL3_Mouse(KickstartCommand):

--- a/pykickstart/commands/multipath.py
+++ b/pykickstart/commands/multipath.py
@@ -22,7 +22,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC6_MpPathData(BaseData):

--- a/pykickstart/commands/multipath.py
+++ b/pykickstart/commands/multipath.py
@@ -23,7 +23,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_MpPathData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/network.py
+++ b/pykickstart/commands/network.py
@@ -24,7 +24,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 MIN_VLAN_ID = 0
 MAX_VLAN_ID = 4095

--- a/pykickstart/commands/network.py
+++ b/pykickstart/commands/network.py
@@ -22,7 +22,6 @@ from pykickstart.constants import BOOTPROTO_BOOTP, BOOTPROTO_DHCP, BOOTPROTO_IBF
 from pykickstart.options import KSOptionParser
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/nfs.py
+++ b/pykickstart/commands/nfs.py
@@ -20,9 +20,6 @@
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
-from pykickstart import _
-
 class FC3_NFS(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs

--- a/pykickstart/commands/nfs.py
+++ b/pykickstart/commands/nfs.py
@@ -21,7 +21,7 @@ from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_NFS(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -19,9 +19,6 @@
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
-from pykickstart import _
-
 class F21_OSTreeSetup(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -20,7 +20,7 @@ from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F21_OSTreeSetup(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_PartData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_RaidData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -62,7 +62,7 @@ class F19_Realm(KickstartCommand):
                                                        "one-time-password=",
                                                        "no-password",
                                                        "computer-ou="))
-        except getopt.GetoptError, ex:
+        except getopt.GetoptError as ex:
             raise KickstartValueError(formatErrorMsg(self.lineno, msg=_(
                 "Invalid realm arguments: %s") % ex))
 

--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -26,7 +26,7 @@ import pipes
 import shlex
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F19_Realm(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -25,7 +25,6 @@ import getopt
 import pipes
 import shlex
 
-import gettext
 from pykickstart import _
 
 class F19_Realm(KickstartCommand):

--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_RepoData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/rescue.py
+++ b/pykickstart/commands/rescue.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class F10_Rescue(KickstartCommand):

--- a/pykickstart/commands/rescue.py
+++ b/pykickstart/commands/rescue.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F10_Rescue(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/rootpw.py
+++ b/pykickstart/commands/rootpw.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_RootPw(KickstartCommand):

--- a/pykickstart/commands/rootpw.py
+++ b/pykickstart/commands/rootpw.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_RootPw(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/services.py
+++ b/pykickstart/commands/services.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_Services(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/services.py
+++ b/pykickstart/commands/services.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC6_Services(KickstartCommand):

--- a/pykickstart/commands/skipx.py
+++ b/pykickstart/commands/skipx.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_SkipX(KickstartCommand):

--- a/pykickstart/commands/skipx.py
+++ b/pykickstart/commands/skipx.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_SkipX(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/sshkey.py
+++ b/pykickstart/commands/sshkey.py
@@ -22,8 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 import warnings
 
-import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F22_SshKeyData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/sshpw.py
+++ b/pykickstart/commands/sshpw.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 import warnings
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F13_SshPwData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/sshpw.py
+++ b/pykickstart/commands/sshpw.py
@@ -22,7 +22,6 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 import warnings
 
-import gettext
 from pykickstart import _
 
 class F13_SshPwData(BaseData):

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Timezone(KickstartCommand):

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartParseError, KickstartValueError, formatE
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Timezone(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/unsupported_hardware.py
+++ b/pykickstart/commands/unsupported_hardware.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class RHEL6_UnsupportedHardware(KickstartCommand):

--- a/pykickstart/commands/unsupported_hardware.py
+++ b/pykickstart/commands/unsupported_hardware.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class RHEL6_UnsupportedHardware(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/updates.py
+++ b/pykickstart/commands/updates.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class F7_Updates(KickstartCommand):

--- a/pykickstart/commands/updates.py
+++ b/pykickstart/commands/updates.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class F7_Updates(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/upgrade.py
+++ b/pykickstart/commands/upgrade.py
@@ -21,7 +21,6 @@ from pykickstart.base import DeprecatedCommand, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Upgrade(KickstartCommand):

--- a/pykickstart/commands/upgrade.py
+++ b/pykickstart/commands/upgrade.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Upgrade(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/url.py
+++ b/pykickstart/commands/url.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_Url(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/url.py
+++ b/pykickstart/commands/url.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_Url(KickstartCommand):

--- a/pykickstart/commands/user.py
+++ b/pykickstart/commands/user.py
@@ -20,7 +20,6 @@
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/user.py
+++ b/pykickstart/commands/user.py
@@ -22,7 +22,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC6_UserData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -21,7 +21,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -23,7 +23,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_VolGroupData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/commands/xconfig.py
+++ b/pykickstart/commands/xconfig.py
@@ -21,7 +21,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_XConfig(KickstartCommand):

--- a/pykickstart/commands/xconfig.py
+++ b/pykickstart/commands/xconfig.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_XConfig(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/zerombr.py
+++ b/pykickstart/commands/zerombr.py
@@ -24,7 +24,7 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_ZeroMbr(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/zerombr.py
+++ b/pykickstart/commands/zerombr.py
@@ -23,7 +23,6 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
 from pykickstart import _
 
 class FC3_ZeroMbr(KickstartCommand):

--- a/pykickstart/commands/zfcp.py
+++ b/pykickstart/commands/zfcp.py
@@ -20,7 +20,6 @@
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
 
-import gettext
 import warnings
 from pykickstart import _
 

--- a/pykickstart/commands/zfcp.py
+++ b/pykickstart/commands/zfcp.py
@@ -22,7 +22,7 @@ from pykickstart.options import KSOptionParser
 
 import gettext
 import warnings
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class FC3_ZFCPData(BaseData):
     removedKeywords = BaseData.removedKeywords

--- a/pykickstart/errors.py
+++ b/pykickstart/errors.py
@@ -36,7 +36,6 @@ It also exports several exception classes:
     KickstartVersionError - An exception for errors relating to unsupported
                             syntax versions.
 """
-import gettext
 from pykickstart import _
 
 def formatErrorMsg(lineno, msg=""):

--- a/pykickstart/errors.py
+++ b/pykickstart/errors.py
@@ -37,7 +37,7 @@ It also exports several exception classes:
                             syntax versions.
 """
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 def formatErrorMsg(lineno, msg=""):
     """Properly format the error message msg for inclusion in an exception."""

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -34,7 +34,6 @@ from optparse import Option, OptionError, OptionParser, OptionValueError
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.version import versionToString
 
-import gettext
 from pykickstart import _
 
 class KSOptionParser(OptionParser):

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -35,7 +35,7 @@ from pykickstart.errors import KickstartParseError, KickstartValueError, formatE
 from pykickstart.version import versionToString
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class KSOptionParser(OptionParser):
     """A specialized subclass of optparse.OptionParser to handle extra option

--- a/pykickstart/orderedset.py
+++ b/pykickstart/orderedset.py
@@ -27,7 +27,7 @@ class OrderedSet(collections.MutableSet):
 
     def discard(self, key):
         if key in self.map:
-            key, prev, next = self.map.pop(key)
+            key, prev, next = self.map.pop(key) # pylint: disable=redefined-builtin
             prev[2] = next
             next[1] = prev
 
@@ -45,7 +45,7 @@ class OrderedSet(collections.MutableSet):
             yield curr[0]
             curr = curr[1]
 
-    def pop(self, last=True):
+    def pop(self, last=True): # pylint: disable=arguments-differ
         if not self:
             raise KeyError('set is empty')
         key = self.end[1][0] if last else self.end[2][0]

--- a/pykickstart/orderedset.py
+++ b/pykickstart/orderedset.py
@@ -1,0 +1,63 @@
+# Copyright 2009 Raymond Hettinger
+# Distributed under the MIT license
+# Obtained at http://code.activestate.com/recipes/576694/
+
+import collections
+
+class OrderedSet(collections.MutableSet):
+
+    def __init__(self, iterable=None):
+        self.end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.map = {}                   # key --> [key, prev, next]
+        if iterable is not None:
+            self |= iterable
+
+    def __len__(self):
+        return len(self.map)
+
+    def __contains__(self, key):
+        return key in self.map
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def discard(self, key):
+        if key in self.map:
+            key, prev, next = self.map.pop(key)
+            prev[2] = next
+            next[1] = prev
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def pop(self, last=True):
+        if not self:
+            raise KeyError('set is empty')
+        key = self.end[1][0] if last else self.end[2][0]
+        self.discard(key)
+        return key
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, list(self))
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedSet):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -260,15 +260,23 @@ class Group:
         else:
             return "@%s" % self.name
 
-    def __cmp__(self, other):
-        if self.name < other.name:
-            return -1
-        elif self.name > other.name:
-            return 1
-        return 0
-
     def __lt__(self, other):
         return bool(self.name < other.name)
+
+    def __le__(self, other):
+        return bool(self.name <= other.name)
+
+    def __eq__(self, other):
+        return bool(self.name == other.name)
+
+    def __ne__(self, other):
+        return bool(self.name != other.name)
+
+    def __gt__(self, other):
+        return bool(self.name > other.name)
+
+    def __ge__(self, other):
+        return bool(self.name >= other.name)
 
 class Packages(KickstartObject):
     """A class representing the %packages section of the kickstart file."""

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -33,6 +33,7 @@ This module exports several important classes:
 
 from collections import Iterator
 import os
+import six
 import shlex
 import tempfile
 from io import StringIO
@@ -77,6 +78,9 @@ def _preprocessStateMachine (lineIter):
 
         ll = l.strip()
         if not ll.startswith("%ksappend"):
+            if six.PY3:
+                import sys
+                l = l.encode(sys.getdefaultencoding())
             os.write(outF, l)
             continue
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -35,9 +35,10 @@ from collections import Iterator
 import os
 import shlex
 import tempfile
+from io import StringIO
 from optparse import OptionParser
-from urlgrabber import urlread
-import urlgrabber.grabber as grabber
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.error import URLError
 
 from pykickstart import constants, version
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartValueError, formatErrorMsg
@@ -62,7 +63,7 @@ def _preprocessStateMachine (lineIter):
 
     while True:
         try:
-            l = lineIter.next()
+            l = next(lineIter)
         except StopIteration:
             break
 
@@ -85,9 +86,12 @@ def _preprocessStateMachine (lineIter):
             raise KickstartParseError(formatErrorMsg(lineno, msg=_("Illegal url for %%ksappend: %s") % ll))
 
         try:
-            url = grabber.urlopen(ksurl)
-        except grabber.URLGrabError, e:
-            raise KickstartError(formatErrorMsg(lineno, msg=_("Unable to open %%ksappend file: %s") % e.strerror))
+            if '://' in ksurl:
+                url = urlopen(ksurl)
+            else:
+                url = open(ksurl, 'r')
+        except (URLError, IOError) as e:
+            raise KickstartError(formatErrorMsg(lineno, msg=_("Unable to open %%ksappend file: %s") % str(e)))
         else:
             # Sanity check result.  Sometimes FTP doesn't catch a file
             # is missing.
@@ -116,7 +120,7 @@ def preprocessFromString (s):
         run.  Returns the location of the complete kickstart file.
     """
     i = iter(s.splitlines(True) + [""])
-    rc = _preprocessStateMachine (i.next)
+    rc = _preprocessStateMachine (i.__next__)
     return rc
 
 def preprocessKickstart (f):
@@ -126,9 +130,12 @@ def preprocessKickstart (f):
         run.  Returns the location of the complete kickstart file.
     """
     try:
-        fh = grabber.urlopen(f)
-    except grabber.URLGrabError, e:
-        raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % e.strerror))
+        if '://' in f:
+            fh = urlopen(f)
+        else:
+            fh = open(f, 'r')
+    except (URLError, IOError) as e:
+        raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % str(e)))
 
     rc = _preprocessStateMachine (iter(fh.readlines()))
     fh.close()
@@ -151,7 +158,10 @@ class PutBackIterator(Iterator):
             self._buf = None
             return retval
         else:
-            return self._iterable.next()
+            return next(self._iterable)
+
+    def __next__(self):
+        return self.next()
 
 ###
 ### SCRIPT HANDLING
@@ -533,7 +543,7 @@ class KickstartParser:
 
         while True:
             try:
-                line = lineIter.next()
+                line = next(lineIter)
                 if line == "" and self._includeDepth == 0:
                     # This section ends at the end of the file.
                     if self.version >= version.F8:
@@ -604,7 +614,7 @@ class KickstartParser:
         """
         try:
             fn()
-        except Exception, msg:
+        except Exception as msg:
             if self.errorsAreFatal:
                 raise
             else:
@@ -638,7 +648,7 @@ class KickstartParser:
         while True:
             # Get the next line out of the file, quitting if this is the last line.
             try:
-                self._line = lineIter.next()
+                self._line = next(lineIter)
                 if self._line == "":
                     break
             except StopIteration:
@@ -723,9 +733,9 @@ class KickstartParser:
         self.currentdir[self._includeDepth] = cd
 
         try:
-            s = urlread(f)
-        except grabber.URLGrabError, e:
-            raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % e.strerror))
+            s = open(f, 'r').read()
+        except IOError as e:
+            raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % str(e)))
 
         self.readKickstartFromString(s, reset=False)
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -737,7 +737,8 @@ class KickstartParser:
         self.currentdir[self._includeDepth] = cd
 
         try:
-            s = open(f, 'r').read()
+            with open(f, 'r') as fh:
+                s = fh.read()
         except IOError as e:
             raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % str(e)))
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -263,6 +263,9 @@ class Group:
             return 1
         return 0
 
+    def __lt__(self, other):
+        return bool(self.name < other.name)
+
 class Packages(KickstartObject):
     """A class representing the %packages section of the kickstart file."""
     def __init__(self, *args, **kwargs):

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -46,7 +46,7 @@ from pykickstart.ko import KickstartObject
 from pykickstart.sections import PackageSection, PreScriptSection, PostScriptSection, TracebackScriptSection
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 STATE_END = "end"
 STATE_COMMANDS = "commands"

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -259,22 +259,22 @@ class Group:
             return "@%s" % self.name
 
     def __lt__(self, other):
-        return bool(self.name < other.name)
+        return self.name < other.name
 
     def __le__(self, other):
-        return bool(self.name <= other.name)
+        return self.name <= other.name
 
     def __eq__(self, other):
-        return bool(self.name == other.name)
+        return self.name == other.name
 
     def __ne__(self, other):
-        return bool(self.name != other.name)
+        return self.name != other.name
 
     def __gt__(self, other):
-        return bool(self.name > other.name)
+        return self.name > other.name
 
     def __ge__(self, other):
-        return bool(self.name >= other.name)
+        return self.name >= other.name
 
 class Packages(KickstartObject):
     """A class representing the %packages section of the kickstart file."""

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -36,7 +36,6 @@ import os
 import six
 import shlex
 import tempfile
-from io import StringIO
 from optparse import OptionParser
 from six.moves.urllib.request import urlopen # pylint: disable=no-name-in-module,import-error
 from six.moves.urllib.error import URLError # pylint: disable=no-name-in-module,import-error
@@ -47,7 +46,6 @@ from pykickstart.ko import KickstartObject
 from pykickstart.orderedset import OrderedSet
 from pykickstart.sections import PackageSection, PreScriptSection, PostScriptSection, TracebackScriptSection
 
-import gettext
 from pykickstart import _
 
 STATE_END = "end"

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -43,6 +43,7 @@ from six.moves.urllib.error import URLError
 from pykickstart import constants, version
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.ko import KickstartObject
+from pykickstart.orderedset import OrderedSet
 from pykickstart.sections import PackageSection, PreScriptSection, PostScriptSection, TracebackScriptSection
 
 import gettext
@@ -391,10 +392,10 @@ class Packages(KickstartObject):
         """Given a list of lines from the input file, strip off any leading
            symbols and add the result to the appropriate list.
         """
-        existingExcludedSet = set(self.excludedList)
-        existingPackageSet = set(self.packageList)
-        newExcludedSet = set()
-        newPackageSet = set()
+        existingExcludedSet = OrderedSet(self.excludedList)
+        existingPackageSet = OrderedSet(self.packageList)
+        newExcludedSet = OrderedSet()
+        newPackageSet = OrderedSet()
 
         excludedGroupList = []
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -38,8 +38,8 @@ import shlex
 import tempfile
 from io import StringIO
 from optparse import OptionParser
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import URLError
+from six.moves.urllib.request import urlopen # pylint: disable=no-name-in-module,import-error
+from six.moves.urllib.error import URLError # pylint: disable=no-name-in-module,import-error
 
 from pykickstart import constants, version
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartValueError, formatErrorMsg

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -36,7 +36,7 @@ from pykickstart.options import KSOptionParser
 from pykickstart.version import FC4, F7, F9, F18, F21
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class Section(object):
     """The base class for defining kickstart sections.  You are free to

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -35,7 +35,6 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 from pykickstart.version import FC4, F7, F9, F18, F21
 
-import gettext
 from pykickstart import _
 
 class Section(object):

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -43,8 +43,13 @@ This module also exports several functions:
                       syntax it uses.  This requires the kickstart file to
                       have a version= comment in it.
 """
-import imputil, re, sys
+import re, sys
 from six.moves.urllib.request import urlopen
+
+try:
+    from imputil import imp
+except ImportError: # Python 3
+    import imp
 
 import gettext
 _ = lambda x: gettext.ldgettext("pykickstart", x)

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -51,7 +51,6 @@ try:
 except ImportError: # Python 3
     import imp
 
-import gettext
 from pykickstart import _
 
 from pykickstart.errors import KickstartVersionError

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -52,7 +52,7 @@ except ImportError: # Python 3
     import imp
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 from pykickstart.errors import KickstartVersionError
 

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -184,8 +184,8 @@ def returnClassForVersion(version=DEVEL):
     try:
         import pykickstart.handlers
         sys.path.extend(pykickstart.handlers.__path__)
-        found = imputil.imp.find_module(module)
-        loaded = imputil.imp.load_module(module, found[0], found[1], found[2])
+        found = imp.find_module(module)
+        loaded = imp.load_module(module, found[0], found[1], found[2])
 
         for (k, v) in list(loaded.__dict__.items()):
             if k.lower().endswith("%shandler" % module):

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -192,6 +192,9 @@ def returnClassForVersion(version=DEVEL):
                 return v
     except:
         raise KickstartVersionError(_("Unsupported version specified: %s") % version)
+    finally: # Closing opened files in imp.load_module
+        if found and len(found) > 0:
+            found[0].close()
 
 def makeVersion(version=DEVEL):
     """Return a new instance of the syntax handler for version.  version can be

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -44,7 +44,7 @@ This module also exports several functions:
                       have a version= comment in it.
 """
 import re, sys
-from six.moves.urllib.request import urlopen
+from six.moves.urllib.request import urlopen # pylint: disable=no-name-in-module,import-error
 
 try:
     from imputil import imp

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@
 
 from distutils.core import setup
 
-setup(name='pykickstart', version='1.99.65',
+setup(name='pykickstart', version='1.99.66',
       description='Python module for manipulating kickstart files',
       author='Chris Lumens', author_email='clumens@redhat.com',
       url='http://fedoraproject.org/wiki/pykickstart',
       scripts=['tools/ksvalidator', 'tools/ksflatten', 'tools/ksverdiff', 'tools/ksshell'],
       packages=['pykickstart', 'pykickstart.commands', 'pykickstart.handlers'],
       data_files=[('share/man/man1', ['docs/ksvalidator.1', 'docs/ksflatten.1', 'docs/ksverdiff.1',
-                                      'docs/ksshell.1'])])
+                                      'docs/ksshell.1'])],
+      install_requires=['six'])

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -19,7 +19,7 @@ from pykickstart.parser import preprocessFromString, KickstartParser
 from pykickstart.version import *
 import gettext
 gettext.textdomain("pykickstart")
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart import _
 
 class ParserTest(unittest.TestCase):
     version = DEVEL

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -2,12 +2,16 @@ import os
 import sys
 import unittest
 import shlex
-import imputil
 import glob
 import warnings
 import re
 import tempfile
 import shutil
+
+try:
+    from imputil import imp
+except ImportError: # Python 3
+    import imp
 
 from pykickstart.errors import *
 from pykickstart.parser import preprocessFromString, KickstartParser
@@ -66,7 +70,7 @@ class ParserTest(unittest.TestCase):
         """
         try:
             self.parser.readKickstartFromString(ks_string)
-        except Exception, e:
+        except Exception as e:
             self.fail("Failed while parsing commands %s: %s" % (ks_string, e))
 
 
@@ -158,7 +162,7 @@ class CommandTest(unittest.TestCase):
         else:
             try:
                 obj = parser.parse(args[1:])
-            except Exception, e:
+            except Exception as e:
                 self.fail("Failed while parsing: %s" % e)
         return obj
 
@@ -225,8 +229,8 @@ def loadModules(moduleDir, cls_pattern="_TestCase", skip_list=["__init__", "base
 
         # Attempt to load the found module.
         try:
-            found = imputil.imp.find_module(module)
-            loaded = imputil.imp.load_module(module, found[0], found[1], found[2])
+            found = imp.find_module(module)
+            loaded = imp.load_module(module, found[0], found[1], found[2])
         except ImportError, e:
             print(_("Error loading module %s: %s") % (module, e))
             continue

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -17,6 +17,7 @@ except ImportError: # Python 3
 from pykickstart.errors import *
 from pykickstart.parser import preprocessFromString, KickstartParser
 from pykickstart.version import *
+import gettext
 gettext.textdomain("pykickstart")
 from pykickstart import _
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -1,4 +1,5 @@
 import os
+import six
 import sys
 import unittest
 import shlex
@@ -61,7 +62,8 @@ class ParserTest(unittest.TestCase):
         By default the KickstartParseError is expected.
         """
 
-        with self.assertRaisesRegexp(exception, regex):
+        assert_function = 'assertRaisesRegexp' if not six.PY3 else 'assertRaisesRegex'
+        with getattr(self, assert_function)(exception, regex):
             self.parser.readKickstartFromString(ks_string)
 
     def assert_parse(self, ks_string):
@@ -172,7 +174,8 @@ class CommandTest(unittest.TestCase):
         parser = self.getParser(inputStr)
         args = shlex.split(inputStr)
 
-        with self.assertRaisesRegexp(exception, regex):
+        assert_function = 'assertRaisesRegexp' if not six.PY3 else 'assertRaisesRegex'
+        with getattr(self, assert_function)(exception, regex):
             parser.parse(args[1:])
 
     def assert_deprecated(self, cmd, opt):

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -17,7 +17,6 @@ except ImportError: # Python 3
 from pykickstart.errors import *
 from pykickstart.parser import preprocessFromString, KickstartParser
 from pykickstart.version import *
-import gettext
 gettext.textdomain("pykickstart")
 from pykickstart import _
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -232,23 +232,27 @@ def loadModules(moduleDir, cls_pattern="_TestCase", skip_list=["__init__", "base
 
         # Attempt to load the found module.
         try:
-            found = imp.find_module(module)
-            loaded = imp.load_module(module, found[0], found[1], found[2])
-        except ImportError, e:
-            print(_("Error loading module %s: %s") % (module, e))
-            continue
+            try:
+                found = imp.find_module(module)
+                loaded = imp.load_module(module, found[0], found[1], found[2])
+            except ImportError as e:
+                print(_("Error loading module %s: %s") % (module, e))
+                continue
 
-        # Find class names that match the supplied pattern (default: "_TestCase")
-        beforeCount = len(tstList)
-        for obj in list(loaded.__dict__.keys()):
-            if obj.endswith(cls_pattern):
-                tstList.append(loaded.__dict__[obj])
-        afterCount = len(tstList)
+            # Find class names that match the supplied pattern (default: "_TestCase")
+            beforeCount = len(tstList)
+            for obj in list(loaded.__dict__.keys()):
+                if obj.endswith(cls_pattern):
+                    tstList.append(loaded.__dict__[obj])
+            afterCount = len(tstList)
 
-        # Warn if no tests found
-        if beforeCount == afterCount:
-            print(_("Module %s does not contain any test cases; skipping.") % module)
-            continue
+            # Warn if no tests found
+            if beforeCount == afterCount:
+                print(_("Module %s does not contain any test cases; skipping.") % module)
+                continue
+        finally: # Closing opened files in imp.load_module
+            if found and len(found) > 0:
+                found[0].close()
 
     return tstList
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -62,7 +62,10 @@ class ParserTest(unittest.TestCase):
         By default the KickstartParseError is expected.
         """
 
-        assert_function = 'assertRaisesRegexp' if not six.PY3 else 'assertRaisesRegex'
+        if not six.PY3:
+            assert_function = 'assertRaisesRegexp'
+        else:
+            assert_function = 'assertRaisesRegex'
         with getattr(self, assert_function)(exception, regex):
             self.parser.readKickstartFromString(ks_string)
 
@@ -174,7 +177,11 @@ class CommandTest(unittest.TestCase):
         parser = self.getParser(inputStr)
         args = shlex.split(inputStr)
 
-        assert_function = 'assertRaisesRegexp' if not six.PY3 else 'assertRaisesRegex'
+        if not six.PY3:
+            assert_function = 'assertRaisesRegexp'
+        else:
+            assert_function = 'assertRaisesRegex'
+
         with getattr(self, assert_function)(exception, regex):
             parser.parse(args[1:])
 

--- a/tests/commands/displaymode.py
+++ b/tests/commands/displaymode.py
@@ -28,23 +28,23 @@ class FC3_TestCase(CommandTest):
 
     def runTest(self):
         # pass
-	self.assert_parse("graphical", "graphical\n")
-	self.assert_parse("text", "text\n")
-	self.assert_parse("cmdline", "cmdline\n")
+        self.assert_parse("graphical", "graphical\n")
+        self.assert_parse("text", "text\n")
+        self.assert_parse("cmdline", "cmdline\n")
 
         # fail
         self.assert_parse_error("graphical --glitter=YES", KickstartParseError)
-	self.assert_parse_error("graphical --shiny", KickstartParseError)
-	self.assert_parse_error("graphical text", KickstartParseError)
-	self.assert_parse_error("graphical cmdline", KickstartParseError)
+        self.assert_parse_error("graphical --shiny", KickstartParseError)
+        self.assert_parse_error("graphical text", KickstartParseError)
+        self.assert_parse_error("graphical cmdline", KickstartParseError)
         self.assert_parse_error("text --glitter=YES", KickstartParseError)
-	self.assert_parse_error("text --shiny", KickstartParseError)
-	self.assert_parse_error("text graphical", KickstartParseError)
-	self.assert_parse_error("text cmdline", KickstartParseError)
-	self.assert_parse_error("cmdline --glitter=YES", KickstartParseError)
-	self.assert_parse_error("cmdline --shiny", KickstartParseError)
-	self.assert_parse_error("cmdline graphical", KickstartParseError)
-	self.assert_parse_error("cmdline text", KickstartParseError)
+        self.assert_parse_error("text --shiny", KickstartParseError)
+        self.assert_parse_error("text graphical", KickstartParseError)
+        self.assert_parse_error("text cmdline", KickstartParseError)
+        self.assert_parse_error("cmdline --glitter=YES", KickstartParseError)
+        self.assert_parse_error("cmdline --shiny", KickstartParseError)
+        self.assert_parse_error("cmdline graphical", KickstartParseError)
+        self.assert_parse_error("cmdline text", KickstartParseError)
 
 
 if __name__ == "__main__":

--- a/tests/commands/dmraid.py
+++ b/tests/commands/dmraid.py
@@ -29,19 +29,19 @@ class FC6_TestCase(CommandTest):
     def runTest(self):
         # pass
         self.assert_parse("dmraid --name=onamai --dev=debaisi", "dmraid --name=onamai --dev=\"debaisi\"\n")
-	self.assert_parse("dmraid --name onamai --dev debaisi", "dmraid --name=onamai --dev=\"debaisi\"\n")
-	self.assert_parse("dmraid --dev=deb1,deb2 --name onamai", "dmraid --name=onamai --dev=\"deb1,deb2\"\n")
-	self.assert_parse("dmraid --dev \"deb1,deb2\" --name=onamai", "dmraid --name=onamai --dev=\"deb1,deb2\"\n")
+        self.assert_parse("dmraid --name onamai --dev debaisi", "dmraid --name=onamai --dev=\"debaisi\"\n")
+        self.assert_parse("dmraid --dev=deb1,deb2 --name onamai", "dmraid --name=onamai --dev=\"deb1,deb2\"\n")
+        self.assert_parse("dmraid --dev \"deb1,deb2\" --name=onamai", "dmraid --name=onamai --dev=\"deb1,deb2\"\n")
 
         # fail
         self.assert_parse_error("dmraid", KickstartValueError)
         self.assert_parse_error("dmraid --name", KickstartParseError)
-	self.assert_parse_error("dmraid --dev", KickstartParseError)
+        self.assert_parse_error("dmraid --dev", KickstartParseError)
         self.assert_parse_error("dmraid --name=onamai", KickstartValueError)
-	self.assert_parse_error("dmraid --name onamai", KickstartValueError)
-	self.assert_parse_error("dmraid --dev debaisi", KickstartValueError)
-	self.assert_parse_error("dmraid --dev=deb1,deb2", KickstartValueError)
-	self.assert_parse_error("dmraid --magic", KickstartParseError)
+        self.assert_parse_error("dmraid --name onamai", KickstartValueError)
+        self.assert_parse_error("dmraid --dev debaisi", KickstartValueError)
+        self.assert_parse_error("dmraid --dev=deb1,deb2", KickstartValueError)
+        self.assert_parse_error("dmraid --magic", KickstartParseError)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/logging.py
+++ b/tests/commands/logging.py
@@ -29,19 +29,19 @@ class FC6_TestCase(CommandTest):
     def runTest(self):
         # pass
         self.assert_parse("logging", "logging --level=info\n")
-	self.assert_parse("logging --level=debug", "logging --level=debug\n")
-	self.assert_parse("logging --level=info", "logging --level=info\n")
-	self.assert_parse("logging --level=warning", "logging --level=warning\n")
-	self.assert_parse("logging --level=error", "logging --level=error\n")
-	self.assert_parse("logging --level=critical", "logging --level=critical\n")
+        self.assert_parse("logging --level=debug", "logging --level=debug\n")
+        self.assert_parse("logging --level=info", "logging --level=info\n")
+        self.assert_parse("logging --level=warning", "logging --level=warning\n")
+        self.assert_parse("logging --level=error", "logging --level=error\n")
+        self.assert_parse("logging --level=critical", "logging --level=critical\n")
         self.assert_parse("logging --host=HOSTNAME", "logging --level=info --host=HOSTNAME\n")
         self.assert_parse("logging --host=HOSTNAME --port=PORT", "logging --level=info --host=HOSTNAME --port=PORT\n")
 
         # fail
         self.assert_parse_error("logging --level=theprincessisinanothercastle", KickstartParseError)
         self.assert_parse_error("logging --host", KickstartParseError)
-	self.assert_parse_error("logging --port", KickstartParseError)
-	self.assert_parse_error("logging --port=PORT", KickstartParseError)
+        self.assert_parse_error("logging --port", KickstartParseError)
+        self.assert_parse_error("logging --port=PORT", KickstartParseError)
 
 
 if __name__ == "__main__":

--- a/tests/commands/logvol.py
+++ b/tests/commands/logvol.py
@@ -6,6 +6,8 @@ from pykickstart.errors import *
 from pykickstart.version import *
 from pykickstart.commands.logvol import *
 
+ARG_STR = 'an' if not six.PY3 else '1' # Optparse changed outputs in Python 3
+
 class FC3_TestCase(CommandTest):
     command = "logvol"
 
@@ -94,7 +96,7 @@ class FC4_TestCase(FC3_TestCase):
 
             # fail - missing value
             self.assert_parse_error("logvol / --bytes-per-inode --name=NAME --vgname=VGNAME", KickstartParseError, "option --bytes-per-inode: invalid integer value: '--name=NAME'")
-            self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --bytes-per-inode", KickstartParseError, "--bytes-per-inode option requires an argument")
+            self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --bytes-per-inode", KickstartParseError, "--bytes-per-inode option requires %s argument" % ARG_STR)
 
         if "--encrypted" in self.optionList:
             # Just --encrypted
@@ -118,7 +120,7 @@ class FC4_TestCase(FC3_TestCase):
                               "logvol /  --size=1024 %s--name=NAME --vgname=VGNAME\n" % self.bytesPerInode)
 
             # fail - missing value
-            self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --encrypted --passphrase", KickstartParseError, "--passphrase option requires an argument")
+            self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --encrypted --passphrase", KickstartParseError, "--passphrase option requires %s argument" % ARG_STR)
 
             # fail - --encrypted does not take a value
             self.assert_parse_error("logvol / --encrypted=1 --name=NAME --vgname=VGNAME", KickstartParseError, "--encrypted option does not take a value")
@@ -134,7 +136,7 @@ class F9_TestCase(FC4_TestCase):
         self.assert_type("logvol", "fsprofile", "string")
 
         # fail - missing value
-        self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --fsprofile", KickstartParseError, "--fsprofile option requires an argument")
+        self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --fsprofile", KickstartParseError, "--fsprofile option requires %s argument" % ARG_STR)
 
         # Using --fsprofile
         self.assert_parse("logvol / --size=1024 --fsprofile \"FS_PROFILE\" --name=NAME --vgname=VGNAME",

--- a/tests/commands/logvol.py
+++ b/tests/commands/logvol.py
@@ -6,7 +6,10 @@ from pykickstart.errors import *
 from pykickstart.version import *
 from pykickstart.commands.logvol import *
 
-ARG_STR = 'an' if not six.PY3 else '1' # Optparse changed outputs in Python 3
+if not six.PY3:
+    ARG_STR = 'an'
+else:
+    ARG_STR = '1' # Optparse changed outputs in Python 3
 
 class FC3_TestCase(CommandTest):
     command = "logvol"

--- a/tests/commands/updates.py
+++ b/tests/commands/updates.py
@@ -12,8 +12,8 @@ class F7_TestCase(CommandTest):
         self.assert_parse("updates", "updates\n")
         self.assert_parse("updates deliciouscheeses", "updates deliciouscheeses\n")
 
-	# fail
-	self.assert_parse_error("updates cheese crackers", KickstartValueError)
+        # fail
+        self.assert_parse_error("updates cheese crackers", KickstartValueError)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -1,4 +1,8 @@
-from string import strip
+try:
+    from string import strip
+except ImportError: # Python 3
+    strip = str.strip
+
 import unittest
 from tests.baseclass import *
 

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -1,7 +1,3 @@
-try:
-    from string import strip
-except ImportError: # Python 3
-    strip = str.strip
 
 import unittest
 from tests.baseclass import *
@@ -25,7 +21,7 @@ class AddGlobs_TestCase(DevelPackagesBase):
 kde*
 vim-*
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class AddGroups_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -40,21 +36,21 @@ class AddGroups_TestCase(DevelPackagesBase):
 @GroupC
 @group-b
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
         pkgs = Packages()
         pkgs.add(["@group-a --nodefaults"])
         self.assertEqual("""%packages
 @group-a --nodefaults
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
         pkgs = Packages()
         pkgs.add(["@group-a --optional"])
         self.assertEqual("""%packages
 @group-a --optional
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
         self.assertRaises(KickstartValueError, pkgs.add, ["@group-b --optional --nodefaults"])
 
@@ -70,7 +66,7 @@ class AddGroupsAndEnvironment_TestCase(DevelPackagesBase):
 @GroupB
 packageC
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class AddPackages_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -84,7 +80,7 @@ packageA
 packageB
 packageC
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class ExcludeGlobs_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -98,7 +94,7 @@ class ExcludeGlobs_TestCase(DevelPackagesBase):
 -kde*
 -perl*
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class ExcludeGroups_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -110,7 +106,7 @@ class ExcludeGroups_TestCase(DevelPackagesBase):
 -@Clustering
 -@Conflicts
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class ExcludePackage_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -124,7 +120,7 @@ class ExcludePackage_TestCase(DevelPackagesBase):
 -enlightenment
 -libass
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class Mixed1_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -137,7 +133,7 @@ class Mixed1_TestCase(DevelPackagesBase):
 @group-b
 -@group-a
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class Mixed2_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -150,7 +146,7 @@ class Mixed2_TestCase(DevelPackagesBase):
 package-b
 -vim-enhanced
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class Mixed3_TestCase(DevelPackagesBase):
     def runTest(self):
@@ -164,7 +160,7 @@ package-b
 vim-enhanced
 -vim*
 
-%end""", strip(str(pkgs)))
+%end""", str(pkgs).strip())
 
 class MultiLib_TestCase(DevelPackagesBase):
     def runTest(self):

--- a/tests/parser/handle_unicode.py
+++ b/tests/parser/handle_unicode.py
@@ -15,12 +15,16 @@ rootpw ááááááááá
 echo áááááá
 %end
 """
+    def get_encoded_str(self, string, force_encode=False):
+        if force_encode or not six.PY3:
+            return string.encode("utf-8")
+        else:
+            return string
+
 
     def runTest(self):
         unicode_str1 = u"ááááááááá"
         unicode_str2 = u"áááááá"
-        encoded_str1 = unicode_str1.encode("utf-8")
-        encoded_str2 = unicode_str2.encode("utf-8")
 
         # parser should parse string including non-ascii characters
         self.parser.readKickstartFromString(self.ks)
@@ -29,22 +33,22 @@ echo áááááá
         # original non-ascii strings as utf-8 encoded byte strings and
         # str(self.handler) should not fail -- i.e. self.handler.__str__()
         # should return byte string not unicode string
-        self.assertIn(encoded_str1 if not six.PY3 else unicode_str1, str(self.handler))
-        self.assertIn(encoded_str2 if not six.PY3 else unicode_str1, str(self.handler))
+        self.assertIn(self.get_encoded_str(unicode_str1), str(self.handler))
+        self.assertIn(self.get_encoded_str(unicode_str2), str(self.handler))
 
         # set root password to unicode string
         self.handler.rootpw.password = unicode_str1
 
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
-        self.assertIn(encoded_str1 if not six.PY3 else unicode_str1, str(self.handler))
+        self.assertIn(self.get_encoded_str(unicode_str1), str(self.handler))
 
         # set root password to encoded string
-        self.handler.rootpw.password = encoded_str1
+        self.handler.rootpw.password = self.get_encoded_str(unicode_str1, force_encode=True)
 
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
-        self.assertIn(encoded_str1 if not six.PY3 else str(encoded_str1), str(self.handler))
+        self.assertIn(str(self.get_encoded_str(unicode_str1, force_encode=True)), str(self.handler))
 
 if __name__ == "__main__":
     if not six.PY3:

--- a/tests/parser/handle_unicode.py
+++ b/tests/parser/handle_unicode.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import six
 import unittest
 from tests.baseclass import *
 
@@ -28,22 +29,23 @@ echo áááááá
         # original non-ascii strings as utf-8 encoded byte strings and
         # str(self.handler) should not fail -- i.e. self.handler.__str__()
         # should return byte string not unicode string
-        self.assertIn(encoded_str1, str(self.handler))
-        self.assertIn(encoded_str2, str(self.handler))
+        self.assertIn(encoded_str1 if not six.PY3 else unicode_str1, str(self.handler))
+        self.assertIn(encoded_str2 if not six.PY3 else unicode_str1, str(self.handler))
 
         # set root password to unicode string
         self.handler.rootpw.password = unicode_str1
 
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
-        self.assertIn(encoded_str1, str(self.handler))
+        self.assertIn(encoded_str1 if not six.PY3 else unicode_str1, str(self.handler))
 
         # set root password to encoded string
         self.handler.rootpw.password = encoded_str1
 
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
-        self.assertIn(encoded_str1, str(self.handler))
+        self.assertIn(encoded_str1 if not six.PY3 else str(encoded_str1), str(self.handler))
 
 if __name__ == "__main__":
-    unittest.main()
+    if not six.PY3:
+        unittest.main()

--- a/tests/parser/include.py
+++ b/tests/parser/include.py
@@ -13,7 +13,11 @@ class Base_Include(ParserTest):
         ParserTest.setUp(self)
 
         (handle, self._path) = tempfile.mkstemp(prefix="include-", text=True)
-        os.write(handle, self.includeKS if not six.PY3 else self.includeKS.encode('utf-8'))
+        ks = self.includeKS
+        if six.PY3:
+            ks = ks.encode('utf-8')
+
+        os.write(handle, ks)
         os.close(handle)
 
     def tearDown(self):

--- a/tests/parser/include.py
+++ b/tests/parser/include.py
@@ -1,4 +1,5 @@
 import os
+import six
 import unittest
 import tempfile
 from tests.baseclass import *
@@ -11,8 +12,8 @@ class Base_Include(ParserTest):
     def setUp(self):
         ParserTest.setUp(self)
 
-        (handle, self._path) = tempfile.mkstemp(prefix="include-")
-        os.write(handle, self.includeKS)
+        (handle, self._path) = tempfile.mkstemp(prefix="include-", text=True)
+        os.write(handle, self.includeKS if not six.PY3 else self.includeKS.encode('utf-8'))
         os.close(handle)
 
     def tearDown(self):

--- a/tests/parser/packages.py
+++ b/tests/parser/packages.py
@@ -11,6 +11,7 @@ class Packages_Contains_Comments_TestCase(ParserTest):
 packageA    # this is an end-of-line comment
 # this is a whole line comment
 packageB
+packageC
 %end
 """
 
@@ -18,9 +19,10 @@ packageB
         self.parser.readKickstartFromString(self.ks)
 
         # Verify that the packages are what we think they are.
-        self.assertEqual(len(self.handler.packages.packageList), 2)
+        self.assertEqual(len(self.handler.packages.packageList), 3)
         self.assertEqual(self.handler.packages.packageList[0], "packageA")
         self.assertEqual(self.handler.packages.packageList[1], "packageB")
+        self.assertEqual(self.handler.packages.packageList[2], "packageC")
 
 class Packages_Contains_Nobase_1_TestCase(ParserTest):
     ks = """

--- a/tests/version.py
+++ b/tests/version.py
@@ -222,7 +222,9 @@ class versionFromFile_TestCase(CommandTest):
 
         def write_ks_cfg(buf):
             (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp", text=True)
-            os.write(fd, buf if not six.PY3 else buf.encode('utf-8'))
+            if six.PY3:
+                buf = buf.encode(sys.getdefaultencoding())
+            os.write(fd, buf)
             os.close(fd)
             return name
 

--- a/tests/version.py
+++ b/tests/version.py
@@ -1,3 +1,4 @@
+import six
 import unittest
 import tempfile
 from tests.baseclass import *
@@ -220,8 +221,8 @@ class versionFromFile_TestCase(CommandTest):
     def runTest(self):
 
         def write_ks_cfg(buf):
-            (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp")
-            os.write(fd, buf)
+            (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp", text=True)
+            os.write(fd, buf if not six.PY3 else buf.encode('utf-8'))
             os.close(fd)
             return name
 

--- a/tools/ksflatten
+++ b/tools/ksflatten
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Simple script to take a kickstart config, read it in, parse any %includes,
 # etc to write out a flattened config that is stand-alone
@@ -26,11 +26,11 @@ import sys
 import argparse
 import pykickstart
 import pykickstart.parser
+from pykickstart import _
 from pykickstart.version import DEVEL, makeVersion
 
 import gettext
 gettext.textdomain("pykickstart")
-_ = lambda x: gettext.ldgettext("pykickstart", x)
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/tools/ksshell
+++ b/tools/ksshell
@@ -197,7 +197,7 @@ print("Press ^D to exit.")
 
 while True:
     try:
-        line = six.moves.input("ks> ")
+        line = six.moves.input("ks> ") # pylint: disable=no-member
     except EOFError:
         # ^D was hit, time to quit.
         break

--- a/tools/ksshell
+++ b/tools/ksshell
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Chris Lumens <clumens@redhat.com>
 #
@@ -34,15 +34,15 @@
 
 import readline
 import argparse
-import os, sys
+import os, six, sys
 
+from pykickstart import _
 from pykickstart.errors import KickstartError, KickstartVersionError
 from pykickstart.parser import KickstartParser, preprocessKickstart
 from pykickstart.version import DEVEL, makeVersion
 
 import gettext
 gettext.textdomain("pykickstart")
-_ = lambda x: gettext.ldgettext("pykickstart", x)
 
 ##
 ## INTERNAL COMMANDS
@@ -80,10 +80,10 @@ class KickstartCompleter(object):
         # { command_name: [options] }
         self.commands = {}
 
-        for (cStr, cObj) in handler.commands.iteritems():
+        for (cStr, cObj) in handler.commands.items():
             self._add_command(cStr, cObj)
 
-        for (cStr, cObj) in internal.iteritems():
+        for (cStr, cObj) in internal.items():
             self._add_command(cStr, cObj)
 
         self.currentCandidates = []
@@ -127,7 +127,7 @@ class KickstartCompleter(object):
                     if beingCompleted:
                         self.currentCandidates = [w for w in candidates if w.startswith(beingCompleted)]
                     else:
-                        self.currentCandidates = candidates
+                        self.currentCandidates = list(candidates)
                 except (KeyError, IndexError):
                     self.currentCandidates = []
 
@@ -197,7 +197,7 @@ print("Press ^D to exit.")
 
 while True:
     try:
-        line = raw_input("ks> ")
+        line = six.moves.input("ks> ")
     except EOFError:
         # ^D was hit, time to quit.
         break

--- a/tools/ksvalidator
+++ b/tools/ksvalidator
@@ -30,8 +30,8 @@ from pykickstart import _
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartValueError, KickstartVersionError
 from pykickstart.parser import KickstartParser, preprocessKickstart
 from pykickstart.version import DEVEL, makeVersion, versionMap
-from six.moves.urllib.request import urlretrieve
-from six.moves.urllib.error import URLError
+from six.moves.urllib.request import urlretrieve # pylint: disable=no-name-in-module,import-error
+from six.moves.urllib.error import URLError # pylint: disable=no-name-in-module,import-error
 
 import gettext
 if six.PY3:

--- a/tools/ksvalidator
+++ b/tools/ksvalidator
@@ -26,6 +26,7 @@ import sys
 import warnings
 import tempfile
 import shutil
+from pykickstart import _
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartValueError, KickstartVersionError
 from pykickstart.parser import KickstartParser, preprocessKickstart
 from pykickstart.version import DEVEL, makeVersion, versionMap
@@ -33,8 +34,10 @@ from six.moves.urllib.request import urlretrieve
 from six.moves.urllib.error import URLError
 
 import gettext
-gettext.install("pykickstart", unicode=True)
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+if six.PY3:
+    gettext.install("pykickstart")
+else:
+    gettext.install("pykickstart", unicode=True)
 
 def cleanup(dest, fn=None, exitval=1):
     shutil.rmtree(dest)

--- a/tools/ksvalidator
+++ b/tools/ksvalidator
@@ -21,14 +21,16 @@
 
 import argparse
 import os
+import six
 import sys
 import warnings
 import tempfile
-import urlgrabber
 import shutil
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartValueError, KickstartVersionError
 from pykickstart.parser import KickstartParser, preprocessKickstart
 from pykickstart.version import DEVEL, makeVersion, versionMap
+from six.moves.urllib.request import urlretrieve
+from six.moves.urllib.error import URLError
 
 import gettext
 gettext.install("pykickstart", unicode=True)
@@ -70,8 +72,13 @@ if opts.listversions:
 
 destdir = tempfile.mkdtemp("", "ksvalidator-tmp-", "/tmp")
 try:
-    f = urlgrabber.urlgrab(opts.ksfile, filename="%s/ks.cfg" % destdir)
-except urlgrabber.grabber.URLGrabError, e:
+    filename = "%s/ks.cfg" % destdir
+    if '://' in opts.ksfile:
+        f = urlretrieve(opts.ksfile, filename=filename)[0]
+    else:
+        shutil.copyfile(opts.ksfile, filename)
+        f = filename
+except (URLError, IOError) as e:
     print(_("Error reading %s:\n%s") % (opts.ksfile, e))
     cleanup(destdir)
 

--- a/tools/ksverdiff
+++ b/tools/ksverdiff
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Chris Lumens <clumens@redhat.com>
 #
@@ -21,13 +21,13 @@
 
 import argparse
 import sys
+from pykickstart import _
 from pykickstart.base import DeprecatedCommand
 from pykickstart.errors import KickstartVersionError
 from pykickstart.version import makeVersion, versionMap
 
 import gettext
 gettext.textdomain("pykickstart")
-_ = lambda x: gettext.ldgettext("pykickstart", x)
 
 def getCommandSet(handler):
     return set(handler.commands.keys())
@@ -36,10 +36,7 @@ def getOptSet(lst):
     return set(map(lambda o: o.get_opt_string(), lst))
 
 def printList(lst):
-    for e in lst:
-        sys.stdout.write("%s " % e)
-
-    print
+    print(' '.join(lst))
 
 op = argparse.ArgumentParser()
 op.add_argument("-f", "--from", dest="f")
@@ -72,17 +69,17 @@ toCmdSet = getCommandSet(toHandler)
 bothSet = fromCmdSet & toCmdSet
 
 print(_("The following commands were removed in %s:") % opts.t)
-printList(list(fromCmdSet - toCmdSet))
+printList(sorted(list(fromCmdSet - toCmdSet)))
 
 print(_("The following commands were deprecated in %s:") % opts.t)
-printList(filter(lambda c: isinstance(toHandler.commands[c], DeprecatedCommand), list(bothSet)))
+printList(sorted(filter(lambda c: isinstance(toHandler.commands[c], DeprecatedCommand), list(bothSet))))
 
 print(_("The following commands were added in %s:") % opts.t)
-printList(list(toCmdSet - fromCmdSet))
+printList(sorted(list(toCmdSet - fromCmdSet)))
 
-print
+print('')
 
-for cmd in bothSet:
+for cmd in sorted(list(bothSet)):
     printed = False
 
     newOptList = []
@@ -104,18 +101,18 @@ for cmd in bothSet:
 
     if len(newOptList) > 0:
         print(_("The following options were added to the %s command in %s:") % (cmd, opts.t))
-        printList(list(newOptList))
+        printList(sorted(list(newOptList)))
         printed = True
 
     if len(deprecatedOptList) > 0:
         print(_("The following options were deprecated from the %s command in %s:") % (cmd, opts.t))
-        printList(list(deprecatedOptList))
+        printList(sorted(list(deprecatedOptList)))
         printed = True
 
     if len(removedOptList) > 0:
         print(_("The following options were removed from the %s command in %s:") % (cmd, opts.t))
-        printList(list(removedOptList))
+        printList(sorted(list(removedOptList)))
         printed = True
 
     if printed:
-        print
+        print('')


### PR DESCRIPTION
Tests pass, some basic operations that I tried work as well. With this SPEC, the package built for me in Rawhide Mock all right, and worked as well.

I have taken the liberty to sort the output lists in ksverdiff as I believe it makes more sense to have the differences alphabetically ordered. 

Commits are rebased so that they should make sense individually, therefore I recommend viewing them one by one (the only exception is the SPEC file overhaul in commit 53c9def, that one could arguably be stand-alone).