### PR TITLE
Python 3 compatibility issues fixes

### DIFF
--- a/pykickstart/commands/method.py
+++ b/pykickstart/commands/method.py
@@ -93,6 +93,9 @@ class F19_Method(FC3_Method):
     _methods = FC3_Method._methods + ["liveimg"]
 
     def __getattr__(self, name):
+        if name == "handler":
+            raise AttributeError()
+
         if self.handler.liveimg.seen:
             if name == "method":
                 return "liveimg"


### PR DESCRIPTION
Python 3's ``copy.copy()`` works in a different way and hits more issues caused by
attributes accessed in the ``__getattr__`` override/redefinition. Long story short,
``copy.copy()`` creates a new empty object without calling ``__init__``  which it then
tries to populate with stuff from the copied object and as part of that calls
``hasattr()`` which in Python 3 no longer catches infinite recursion errors. The
solution is to raise ``AttributeError`` for all attributes defined in ``__init__`` that
are accessed from the ``__getattr__`` method override.

See http://nedbatchelder.com/blog/201010/surprising_getattr_recursion.html for
more information. Also kudos to bkabrda for nailing this down!