### PR TITLE
Adapt the Timezone class to support NTP pools

### DIFF
--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -137,3 +137,22 @@ class F18_Timezone(FC6_Timezone):
             raise KickstartParseError(msg)
 
         return self
+
+class F23_Timezone(F18_Timezone):
+    def __init__(self, *args, **kwargs):
+        F18_Timezone.__init__(self, *args, **kwargs)
+        self.ntpservers = kwargs.get("ntpservers", list())
+
+    def _getParser(self):
+        def servers_cb(option, opt_str, value, parser):
+            for server in value.split(","):
+                if server:
+                    parser.values.ensure_value(option.dest, list()).append(server)
+
+
+        op = FC6_Timezone._getParser(self)
+        op.add_option("--nontp", dest="nontp", action="store_true", default=False)
+        op.add_option("--ntpservers", dest="ntpservers", action="callback",
+                      callback=servers_cb, nargs=1, type="string")
+
+        return op

--- a/pykickstart/handlers/f23.py
+++ b/pykickstart/handlers/f23.py
@@ -80,7 +80,7 @@ class F23Handler(BaseHandler):
         "sshpw": commands.sshpw.F13_SshPw,
         "sshkey": commands.sshkey.F22_SshKey,
         "text": commands.displaymode.FC3_DisplayMode,
-        "timezone": commands.timezone.F18_Timezone,
+        "timezone": commands.timezone.F23_Timezone,
         "updates": commands.updates.F7_Updates,
         "upgrade": commands.upgrade.F20_Upgrade,
         "url": commands.url.F18_Url,

--- a/tests/commands/timezone.py
+++ b/tests/commands/timezone.py
@@ -78,5 +78,13 @@ class F18_TestCase(FC6_TestCase):
                                 "ntp.cesnet.cz, tik.nic.cz",
                                 KickstartValueError)
 
+class F23_TestCase(F18_TestCase):
+    def runTest(self):
+        # should keep multiple instances of the same URL
+        self.assert_parse("timezone --utc Europe/Prague --ntpservers=ntp.cesnet.cz,0.fedora.pool.ntp.org,"+
+                          "0.fedora.pool.ntp.org,0.fedora.pool.ntp.org,0.fedora.pool.ntp.org",
+                          "timezone Europe/Prague --isUtc --ntpservers=ntp.cesnet.cz,0.fedora.pool.ntp.org,"+
+                          "0.fedora.pool.ntp.org,0.fedora.pool.ntp.org,0.fedora.pool.ntp.org\n")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
NTP pools are entered by users as using the same NTP server URL multiple times
so we need to store the NTP server URLs in a list not in a set.