### PR TITLE
commands/partition.py updates

### DIFF
--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -322,15 +322,6 @@ class FC4_Partition(FC3_Partition):
     removedKeywords = FC3_Partition.removedKeywords
     removedAttrs = FC3_Partition.removedAttrs
 
-    def __init__(self, writePriority=130, *args, **kwargs):
-        FC3_Partition.__init__(self, writePriority, *args, **kwargs)
-
-        def part_cb (option, opt_str, value, parser):       # pylint: disable=unused-variable
-            if value.startswith("/dev/"):
-                parser.values.ensure_value(option.dest, value[5:])
-            else:
-                parser.values.ensure_value(option.dest, value)
-
     def _getParser(self):
         op = FC3_Partition._getParser(self)
         op.add_option("--bytes-per-inode", dest="bytesPerInode", action="store",
@@ -343,15 +334,6 @@ class RHEL5_Partition(FC4_Partition):
     removedKeywords = FC4_Partition.removedKeywords
     removedAttrs = FC4_Partition.removedAttrs
 
-    def __init__(self, writePriority=130, *args, **kwargs):
-        FC4_Partition.__init__(self, writePriority, *args, **kwargs)
-
-        def part_cb (option, opt_str, value, parser):       # pylint: disable=unused-variable
-            if value.startswith("/dev/"):
-                parser.values.ensure_value(option.dest, value[5:])
-            else:
-                parser.values.ensure_value(option.dest, value)
-
     def _getParser(self):
         op = FC4_Partition._getParser(self)
         op.add_option("--encrypted", action="store_true", default=False)
@@ -361,15 +343,6 @@ class RHEL5_Partition(FC4_Partition):
 class F9_Partition(FC4_Partition):
     removedKeywords = FC4_Partition.removedKeywords
     removedAttrs = FC4_Partition.removedAttrs
-
-    def __init__(self, writePriority=130, *args, **kwargs):
-        FC4_Partition.__init__(self, writePriority, *args, **kwargs)
-
-        def part_cb (option, opt_str, value, parser):       # pylint: disable=unused-variable
-            if value.startswith("/dev/"):
-                parser.values.ensure_value(option.dest, value[5:])
-            else:
-                parser.values.ensure_value(option.dest, value)
 
     def _getParser(self):
         op = FC4_Partition._getParser(self)


### PR DESCRIPTION
Summary of changes: 

1) Remove the parse_cb() and related __init__() methods from the source. As far as I can tell these are not used and are leftovers from older days. Tests pass after removing them. 

More background:

In commit ac7a60b68e0794fabe80a90864c981c756dde2c9 you can see the parse() method which defines a local parse_cb() in FC3Partition and FC4Partition classes. 

Then db23b5709c250976de74041e7105e3c84f95b286 removes the parse() method from FC4_Partition class, leaving the parse_cb() as locally defined method in __init__(). 

Then e0eb4e37bb0c02dfbad398266ad84c3d03590594 adds the new FC9_Partition class where the __init__() method already contains a local parse_cb(). And I guess this is then copied later into inherited classes.

2) Python coverage reports some lines in partition.py as not covered by tests so add or improve existing tests to cover these.