### PR TITLE
Install the python3 .mo files to python3_sitelib

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -6,8 +6,9 @@ INSTALL_DATA	= $(INSTALL) -m 644
 INSTALL_DIR	= /usr/bin/install -d
 
 # destination directory
+PYTHON?=python
 DESTDIR ?= $(RPM_BUILD_ROOT)
-INSTALL_NLS_DIR = $(DESTDIR)/`python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`/$(NLSPACKAGE)/locale
+INSTALL_NLS_DIR = $(DESTDIR)/`$(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`/$(NLSPACKAGE)/locale
 
 # PO catalog handling
 MSGMERGE	= msgmerge -v

--- a/pykickstart.spec
+++ b/pykickstart.spec
@@ -71,7 +71,6 @@ popd
 %install
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} install
-%find_lang %{name}
 
 pushd %{py3dir}
 PYTHON=%{__python3} make DESTDIR=%{buildroot} install
@@ -94,7 +93,7 @@ popd
 %{_bindir}/ksshell
 %{_mandir}/man1/*
 
-%files -n python-kickstart -f %{name}.lang
+%files -n python-kickstart
 %defattr(-,root,root,-)
 %doc docs/programmers-guide
 %doc docs/kickstart-docs.rst
@@ -102,8 +101,9 @@ popd
 %{python2_sitelib}/pykickstart/*py*
 %{python2_sitelib}/pykickstart/commands/*py*
 %{python2_sitelib}/pykickstart/handlers/*py*
+%{python2_sitelib}/pykickstart/locale/
 
-%files -n python3-kickstart -f %{name}.lang
+%files -n python3-kickstart
 %defattr(-,root,root,-)
 %doc docs/programmers-guide
 %doc docs/kickstart-docs.rst
@@ -111,6 +111,7 @@ popd
 %{python3_sitelib}/pykickstart/*py*
 %{python3_sitelib}/pykickstart/commands/*py*
 %{python3_sitelib}/pykickstart/handlers/*py*
+%{python3_sitelib}/pykickstart/locale/
 
 %changelog
 * Tue Jun 02 2015 Chris Lumens <clumens@redhat.com> - 2.8-1


### PR DESCRIPTION
The .mo files in python3-kickstart are being installed to /usr/lib/python2.7/site-packages, which I don't think is what you want.