### PR TITLE
Avoid traceback in module loading failure paths.

### DIFF
--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -188,6 +188,7 @@ def returnClassForVersion(version=DEVEL):
             if k.lower().endswith("%shandler" % module):
                 return v
     except:
+        found = None
         raise KickstartVersionError(_("Unsupported version specified: %s") % version)
     finally: # Closing opened files in imp.load_module
         if found and len(found) > 0:

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -253,6 +253,7 @@ def loadModules(moduleDir, cls_pattern="_TestCase", skip_list=None):
                 loaded = imp.load_module(module, found[0], found[1], found[2])
             except ImportError as e:
                 print(_("Error loading module %s: %s") % (module, e))
+                found = None
                 continue
 
             # Find class names that match the supplied pattern (default: "_TestCase")


### PR DESCRIPTION
I hit a traceback about `found` being undefined or similar when I tried to run the test suite with a syntax error in my new code.