### PR TITLE
autopart root snapshot support

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -227,6 +227,13 @@ large enough drives, this will also create a /home partition.
     scheme and a filesystem. eg. --fstype=ext4. Added in
     anaconda-21.46-1
 
+``--snapshot``
+
+    Create a snapshot of the root device immediately after installation
+    and reconfigure the system so that it uses the snapshot as its root
+    device. Only applicable when --type=thinp or --type=btrfs is also
+    specified.
+
 
 autostep
 --------

--- a/pykickstart/handlers/f23.py
+++ b/pykickstart/handlers/f23.py
@@ -29,7 +29,7 @@ class F23Handler(BaseHandler):
     commandMap = {
         "auth": commands.authconfig.FC3_Authconfig,
         "authconfig": commands.authconfig.FC3_Authconfig,
-        "autopart": commands.autopart.F21_AutoPart,
+        "autopart": commands.autopart.F23_AutoPart,
         "autostep": commands.autostep.FC3_AutoStep,
         "bootloader": commands.bootloader.F21_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,

--- a/tests/commands/autopart.py
+++ b/tests/commands/autopart.py
@@ -169,7 +169,22 @@ class F21_TestCase(F20_TestCase):
         self.assert_parse_error("autopart --fstype=btrfs")
         self.assert_parse_error("autopart --type=btrfs --fstype=xfs")
 
-RHEL7_TestCase = F21_TestCase
+class F23_TestCase(F21_TestCase):
+    def runTest(self):
+        F21_TestCase.runTest(self)
+
+        # pass
+        self.assert_parse("autopart --type=thinp --snapshot",
+                          'autopart --type=thinp --snapshot\n')
+        self.assert_parse("autopart --type=btrfs --snapshot",
+                          'autopart --type=btrfs --snapshot\n')
+
+        # fail
+        self.assert_parse_error("autopart --snapshot")
+        self.assert_parse_error("autopart --type=lvm --snapshot")
+        self.assert_parse_error("autopart --type=partition --snapshot")
+
+RHEL7_TestCase = F23_TestCase
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The rhel7-branch version is only different in that it omits the F23 specifics.

Related: rhbz#1113207