### PR TITLE
Empty instLangs

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -363,7 +363,7 @@ class Packages(KickstartObject):
             retval += " --nocore"
         if self.handleMissing == constants.KS_MISSING_IGNORE:
             retval += " --ignoremissing"
-        if self.instLangs:
+        if self.instLangs is not None:
             retval += " --instLangs=%s" % self.instLangs
         if self.multiLib:
             retval += " --multilib"

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -246,7 +246,7 @@ class PackageSection(Section):
         op.add_option("--default", dest="defaultPackages", action="store_true",
                       default=False, introduced=F7)
         op.add_option("--instLangs", dest="instLangs", type="string",
-                      default="", introduced=F9)
+                      default=None, introduced=F9)
         op.add_option("--multilib", dest="multiLib", action="store_true",
                       default=False, introduced=F18)
 
@@ -267,7 +267,7 @@ class PackageSection(Section):
         if opts.defaultPackages:
             self.handler.packages.default = True
 
-        if opts.instLangs:
+        if opts.instLangs is not None:
             self.handler.packages.instLangs = opts.instLangs
 
         self.handler.packages.nocore = opts.nocore

--- a/tests/parser/packages.py
+++ b/tests/parser/packages.py
@@ -28,6 +28,36 @@ class Packages_Options_TestCase(ParserTest):
         # extra test coverage
         self.assertTrue(self.parser._sections['%packages'].seen)
 
+class Packages_Options_Empty_InstLangs_TestCase(ParserTest):
+    ks = """
+%packages --instLangs=
+%end
+"""
+
+    def runTest(self):
+        self.parser.readKickstartFromString(self.ks)
+
+        # Verify that instLangs is an empty string
+        self.assertEqual(self.handler.packages.instLangs, "")
+
+        # Verify that the empty instLangs comes back out
+        self.assertEqual(str(self.handler.packages).strip(), "%packages --instLangs=\n\n%end")
+
+class Packages_Options_No_InstLangs_TestCase(ParserTest):
+    ks = """
+%packages
+%end
+"""
+
+    def runTest(self):
+        self.parser.readKickstartFromString(self.ks)
+
+        # Verify that instLangs is None
+        self.assertIsNone(self.handler.packages.instLangs)
+
+        # Verify that --instLangs is not displayed
+        self.assertEqual(str(self.handler.packages).strip(), "%packages\n\n%end")
+
 class Packages_Contains_Comments_TestCase(ParserTest):
     ks = """
 %packages


### PR DESCRIPTION
For a kickstart with `%package --instLangs=` set packages.instLangs to "" instead of None.