### PR TITLE
docs: Add `--activate` as an explicit network option to the list

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -1171,8 +1171,12 @@ In F15, the device of first network command is activated also in case of
 non-network installs, and device is not re-activated using kickstart
 configuration.
 
-Additional devices configured in kickstart with network command can be
-activated in installer using ``--activate`` option (since F16).
+``--activate``
+
+    As noted above, using this option ensures any matching devices
+    beyond the first will also be activated.
+
+    Since F16.
 
 ``--bootproto=[dhcp|bootp|static|ibft]``
 


### PR DESCRIPTION
The docs cover `--activate`, but the option isn't included in the
table itself, so if someone visually scans for it they might miss it.

I think this is a bit clearer.

I was looking for `--activate` docs while trying to debug
an Anaconda issue.