### PR TITLE
pykickstart: don't set bootProto if --noipv4

### DIFF
--- a/pykickstart/commands/network.py
+++ b/pykickstart/commands/network.py
@@ -545,6 +545,19 @@ class F22_Network(F21_Network):
 
         return retval
 
+class F24_Network(F22_Network):
+    removedKeywords = F22_Network.removedKeywords
+    removedAttrs = F22_Network.removedAttrs
+
+    def parse(self, args):
+        retval = F22_Network.parse(self, args)
+
+        # If we specify noipv4 then we need to make sure bootproto is zero'ed
+        # out
+        if retval.noipv4:
+            retval.bootProto = ""
+        return retval
+
 class RHEL4_Network(FC3_Network):
     removedKeywords = FC3_Network.removedKeywords
     removedAttrs = FC3_Network.removedAttrs

--- a/pykickstart/handlers/f24.py
+++ b/pykickstart/handlers/f24.py
@@ -60,7 +60,7 @@ class F24Handler(BaseHandler):
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
         "method": commands.method.F19_Method,
         "multipath": commands.multipath.FC6_MultiPath,
-        "network": commands.network.F22_Network,
+        "network": commands.network.F24_Network,
         "nfs": commands.nfs.FC6_NFS,
         "ostreesetup": commands.ostreesetup.F21_OSTreeSetup,
         "part": commands.partition.F23_Partition,

--- a/tests/commands/network.py
+++ b/tests/commands/network.py
@@ -94,6 +94,20 @@ class F22_TestCase(F20_TestCase):
                                 "--bridgeopts=priority",
                                 KickstartValueError)
 
+class F24_TestCase(F22_TestCase):
+    def runTest(self):
+        F22_TestCase.runTest(self)
+
+        # Test ipv4 only settings
+        cmd = "network --noipv4 --activate --hostname=blah.test.com --ipv6=1:2:3:4:5:6:7:8 --device eth0 --nameserver=1:1:1:1::,2:2:2:2::"
+        nd = self.assert_parse(cmd)
+        self.assertEquals(nd.bootProto, "")
+        self.assertEquals(nd.hostname, "blah.test.com")
+        self.assertTrue(nd.noipv4)
+        self.assertEquals(nd.ipv6, "1:2:3:4:5:6:7:8")
+        self.assertIn("1:1:1:1::", nd.nameserver)
+        self.assertIn("2:2:2:2::", nd.nameserver)
+        self.assertEquals(nd.device, "eth0")
 
 class RHEL7_TestCase(F20_TestCase):
     def runTest(self):


### PR DESCRIPTION
If we specify a ipv6 only network configuration we still get bootproto=dhcp set,
which during kickstart makes networkmanager try to do a ipv4 dhcp which takes a
while to timeout.  We don't want bootproto=dhcp set when we specify --noipv4, so
make sure it gets zero'ed out when we see that command.

This is the V2 version that changes f24 and onwards.