### PR TITLE
Make pocketlint optional build dependency

### DIFF
--- a/pykickstart.spec
+++ b/pykickstart.spec
@@ -1,3 +1,5 @@
+%global with_lint 0
+
 Name:      pykickstart
 Version:   2.18
 Release:   1%{?dist}
@@ -23,7 +25,9 @@ BuildRequires: transifex-client
 
 BuildRequires: python3-devel
 BuildRequires: python3-nose
+%if %{?with_lint}
 BuildRequires: python3-pocketlint
+%endif
 BuildRequires: python3-requests
 BuildRequires: python3-setuptools
 BuildRequires: python3-six


### PR DESCRIPTION
As of Fedora23 all core packages runs with python3,
therefore we would like to keep build root for core
packages as small as possible to make the rebuilds
easier of Python3 easier. Please note that pocketlint
doesnt run currently during the build process so its
listing as BuildRequires is redundant.


Pocketlint currently creates a bottleneck of Python3 rebuild as
pocketlint depends on pylint and pylint depends on astroid which
uses private python3 module _ast which api tends to change in between
releases and therefore astroid package doesn't work with python3.5 yet.

Please consider making pocketlint an optional dependency of all anaconda
dependencies to keep the buildroot as small as possible.