### PR TITLE
Read kickstart files in binary, decode to utf-8

### DIFF
--- a/pykickstart/load.py
+++ b/pykickstart/load.py
@@ -92,8 +92,8 @@ def _load_file(filename):
     '''Load a file's contents and return them as a string'''
 
     try:
-        with open(filename, 'r') as fh:
-            contents = fh.read()
+        with open(filename, 'rb') as fh:
+            contents = fh.read().decode("utf-8")
     except IOError as e:
         raise KickstartError(_('Error opening file: %s') % str(e))
 

--- a/tests/parser/handle_unicode.py
+++ b/tests/parser/handle_unicode.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+import os
 import six
 import unittest
+import tempfile
+import locale
+
 from tests.baseclass import ParserTest
 
 class HandleUnicode_TestCase(ParserTest):
@@ -45,6 +49,32 @@ echo áááááá
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
         self.assertIn(str(self.get_encoded_str(unicode_str1, force_encode=True)), str(self.handler))
+
+        # pylint: disable=environment-modify
+        # Make sure the locale is reset so that the traceback could happen
+        del os.environ["LANG"]
+        locale.resetlocale()
+        (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp", text=True)
+        if six.PY3:
+            buf = self.ks.encode("utf-8")
+        else:
+            buf = self.ks
+        os.write(fd, buf)
+        os.close(fd)
+
+        # This should not traceback with a UnicodeError
+        try:
+            self.parser.readKickstart(name)
+
+            # str(handler) should not cause traceback and should contain the
+            # original non-ascii strings as utf-8 encoded byte strings and
+            # str(self.handler) should not fail -- i.e. self.handler.__str__()
+            # should return byte string not unicode string
+            self.assertIn(self.get_encoded_str(unicode_str1), str(self.handler))
+            self.assertIn(self.get_encoded_str(unicode_str2), str(self.handler))
+        finally:
+            os.unlink(name)
+
 
 if __name__ == "__main__":
     if not six.PY3:


### PR DESCRIPTION
If the environment wasn't properly setup (eg. LANG set) then reading a
kickstart with unicode characters would fail. This adds a test to
simulate this, and switches to reading in binary mode and then decoding
to prevent tracebacks.