### PR TITLE
Only decode as utf-8 when using py3

### DIFF
--- a/pykickstart/load.py
+++ b/pykickstart/load.py
@@ -19,6 +19,7 @@
 #
 import requests
 import shutil
+import six
 
 from pykickstart.errors import KickstartError
 from pykickstart.i18n import _
@@ -92,8 +93,12 @@ def _load_file(filename):
     '''Load a file's contents and return them as a string'''
 
     try:
-        with open(filename, 'rb') as fh:
-            contents = fh.read().decode("utf-8")
+        if six.PY3:
+            with open(filename, 'rb') as fh:
+                contents = fh.read().decode("utf-8")
+        else:
+            with open(filename, 'r') as fh:
+                contents = fh.read()
     except IOError as e:
         raise KickstartError(_('Error opening file: %s') % str(e))
 

--- a/tests/parser/handle_unicode.py
+++ b/tests/parser/handle_unicode.py
@@ -26,6 +26,11 @@ echo áááááá
         unicode_str1 = u"ááááááááá"
         unicode_str2 = u"áááááá"
 
+        # pylint: disable=environment-modify
+        # Make sure the locale is reset so that the traceback could happen
+        del os.environ["LANG"]
+        locale.resetlocale()
+
         # parser should parse string including non-ascii characters
         self.parser.readKickstartFromString(self.ks)
 
@@ -50,10 +55,6 @@ echo áááááá
         # original unicode string as utf-8 encoded byte string
         self.assertIn(str(self.get_encoded_str(unicode_str1, force_encode=True)), str(self.handler))
 
-        # pylint: disable=environment-modify
-        # Make sure the locale is reset so that the traceback could happen
-        del os.environ["LANG"]
-        locale.resetlocale()
         (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp", text=True)
         if six.PY3:
             buf = self.ks.encode("utf-8")


### PR DESCRIPTION
The unicode kickstart problem only happens with py3, so conditionalize
_load_file to only decode it when running with py3.