### PR TITLE
Translation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .*.swp
 po/*.po
+po/*.mo
 pykickstart*.tar.gz
 pykickstart*.tar.bz2
 pylint-log

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include COPYING Makefile pykickstart.spec
-recursive-include po *.po *.pot Makefile
+recursive-include po *.po *.pot Makefile *.mo
 recursive-include docs programmers-guide kickstart-docs.rst *.1
-recursive-include tests *.py
+recursive-include tests *.py README.rst

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ docs:
 check:
 	@echo "*** Running pylint to verify source ***"
 	PYTHONPATH=. tests/pylint/runpylint.py
+	@echo "*** Running tests on translatable strings ***"
+	PYTHONPATH=translation-canary python3 -m translation_canary.translatable po/$(PKGNAME).pot
+	@echo "*** Running tests on translated strings ***"
+	PYTHONPATH=translation-canary python3 -m translation_canary.translated .
 
 test:
 	@which nosetests || (echo "*** Please install nosetest (python-nose) ***"; exit 2)

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ archive: check test tag docs
 	cp -r po/*.po $(PKGNAME)-$(VERSION)/po/
 	$(MAKE) -C $(PKGNAME)-$(VERSION)/po
 	cp docs/programmers-guide $(PKGNAME)-$(VERSION)/docs/
+	PYTHONPATH=translation-canary python3 -m translation_canary.translated --release $(PKGNAME)-$(VERSION)
 	( cd $(PKGNAME)-$(VERSION) && $(PYTHON) setup.py -q sdist --dist-dir .. )
 	rm -rf $(PKGNAME)-$(VERSION)
 	git checkout -- po/$(PKGNAME).pot

--- a/Makefile
+++ b/Makefile
@@ -66,26 +66,23 @@ tag:
 	git tag -a -m "Tag as $(TAG)" -f $(TAG)
 	@echo "Tagged as $(TAG)"
 
+# Order matters, so run make twice instead of declaring them as dependencies
+release:
+	$(MAKE) bumpver && $(MAKE) archive
+
 archive: check test tag docs
-	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(TAG) > $(PKGNAME)-$(VERSION).tar
 	mkdir -p $(PKGNAME)-$(VERSION)
-	cp -r po $(PKGNAME)-$(VERSION)/po/
-	mkdir -p $(PKGNAME)-$(VERSION)/docs/
-	cp docs/kickstart-docs.rst $(PKGNAME)-$(VERSION)/docs/
+	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(TAG) | tar -xf -
+	cp -r po/*.po $(PKGNAME)-$(VERSION)/po/
+	$(MAKE) -C $(PKGNAME)-$(VERSION)/po
 	cp docs/programmers-guide $(PKGNAME)-$(VERSION)/docs/
-	tar -rf $(PKGNAME)-$(VERSION).tar $(PKGNAME)-$(VERSION)
-	gzip -9 $(PKGNAME)-$(VERSION).tar
+	( cd $(PKGNAME)-$(VERSION) && $(PYTHON) setup.py -q sdist --dist-dir .. )
 	rm -rf $(PKGNAME)-$(VERSION)
 	git checkout -- po/$(PKGNAME).pot
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 local: docs po-pull
-	@rm -rf $(PKGNAME)-$(VERSION).tar.gz
-	@rm -rf /tmp/$(PKGNAME)-$(VERSION) /tmp/$(PKGNAME)
-	@dir=$$PWD; cp -a $$dir /tmp/$(PKGNAME)-$(VERSION)
-	@cd /tmp/$(PKGNAME)-$(VERSION) ; $(PYTHON) setup.py -q sdist
-	@cp /tmp/$(PKGNAME)-$(VERSION)/dist/$(PKGNAME)-$(VERSION).tar.gz .
-	@rm -rf /tmp/$(PKGNAME)-$(VERSION)
+	@$(PYTHON) setup.py -q sdist --dist-dir .
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 rpmlog:
@@ -134,4 +131,4 @@ rc-release: scratch-bumpver scratch
 ci:
 	$(MAKE) PYTHON=python3 check coverage
 
-.PHONY: check clean install tag archive local docs
+.PHONY: check clean install tag archive local docs release

--- a/po/Makefile
+++ b/po/Makefile
@@ -12,7 +12,7 @@ INSTALL_NLS_DIR = $(DESTDIR)/`$(PYTHON) -c "from distutils.sysconfig import get_
 
 # PO catalog handling
 MSGMERGE	= msgmerge -v
-XGETTEXT	= xgettext --default-domain=$(NLSPACKAGE) \
+XGETTEXT	= ../translation-canary/xgettext_werror.sh --default-domain=$(NLSPACKAGE) \
 		  --add-comments
 MSGFMT		= msgfmt --statistics --verbose
 

--- a/pykickstart/commands/device.py
+++ b/pykickstart/commands/device.py
@@ -120,7 +120,7 @@ class F8_Device(FC3_Device):
         (opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
 
         if len(extra) != 1:
-            raise KickstartValueError(formatErrorMsg(self.lineno, msg=_("%s command requires a single argument: %s") % ("device", "module name")))
+            raise KickstartValueError(formatErrorMsg(self.lineno, msg=_("%(command)s command requires a single argument: %(argument)s") % {"command": "device", "argument": "module name"}))
 
         dd = F8_DeviceData()
         self._setToObj(self.op, opts, dd)

--- a/pykickstart/commands/dmraid.py
+++ b/pykickstart/commands/dmraid.py
@@ -87,7 +87,7 @@ class FC6_DmRaid(KickstartCommand):
 
         # Check for duplicates in the data list.
         if dm in self.dataList():
-            warnings.warn(_("A DM RAID device with the name %s and devices %s has already been defined.") % (dm.name, dm.devices))
+            warnings.warn(_("A DM RAID device with the name %(name)s and devices %(devices)s has already been defined.") % {"name": dm.name, "devices": dm.devices})
 
         return dm
 

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -402,7 +402,7 @@ class FC3_LogVol(KickstartCommand):
 
         # Check for duplicates in the data list.
         if lvd in self.dataList():
-            warnings.warn(_("A logical volume with the name %s has already been defined in volume group %s.") % (lvd.name, lvd.vgname))
+            warnings.warn(_("A logical volume with the name %(logical_volume_name)s has already been defined in volume group %(volume_group)s.") % {"logical_volume_name": lvd.name, "volume_group": lvd.vgname})
 
         return lvd
 

--- a/pykickstart/commands/network.py
+++ b/pykickstart/commands/network.py
@@ -639,7 +639,7 @@ def validate_network_interface_name(name):
     # check if the vlan id is in range
     if vlan_id is not None:
         if not(MIN_VLAN_ID <= vlan_id <= MAX_VLAN_ID):
-            return _("The vlan id out of the %d-%d vlan id range.") % (MIN_VLAN_ID, MAX_VLAN_ID)
+            return _("The vlan id is out of the %(minimum)d-%(maximum)d vlan id range.") % {"minimum": MIN_VLAN_ID, "maximum": MAX_VLAN_ID}
 
     # network interface name seems to be valid (no error found)
     return None

--- a/pykickstart/commands/upgrade.py
+++ b/pykickstart/commands/upgrade.py
@@ -93,7 +93,7 @@ class F11_Upgrade(FC3_Upgrade):
             raise KickstartValueError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s does not take any arguments") % "upgrade"))
 
         if opts.root_device == "":
-            raise KickstartValueError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s does not accept empty parameter %s") % ("upgrade", "--root-device")))
+            raise KickstartValueError(formatErrorMsg(self.lineno, msg=_("Kickstart command %(command)s does not accept empty parameter %(parameter)s") % {"command": "upgrade", "parameter": "--root-device"}))
         else:
             self.root_device = opts.root_device
 

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -11,6 +11,10 @@ class PykickstartLintConfig(PocketLintConfig):
         retval.remove("pocketlint.checkers.eintr")
         return retval
 
+    @property
+    def ignoreNames(self):
+        return {"translation-canary"}
+
 if __name__ == "__main__":
     conf = PykickstartLintConfig()
     linter = PocketLinter(conf)

--- a/tools/ksflatten
+++ b/tools/ksflatten
@@ -51,17 +51,17 @@ def main():
     try:
         ksparser.readKickstart(opts.kscfg)
     except IOError as msg:
-        print(_("Failed to read kickstart file '%s' : %s") % (opts.kscfg, msg), file=sys.stderr)
+        print(_("Failed to read kickstart file '%(filename)s' : %(error_msg)s") % {"filename": opts.kscfg, "error_msg": msg}, file=sys.stderr)
         sys.exit(1)
     except pykickstart.errors.KickstartError as e:
-        print(_("Failed to parse kickstart file '%s' : %s") % (opts.kscfg, e), file=sys.stderr)
+        print(_("Failed to parse kickstart file '%(filename)s' : %(error_msg)s") % {"filename": opts.kscfg, "error_msg": e}, file=sys.stderr)
         sys.exit(1)
 
     if opts.output:
         try:
             f = open(opts.output, 'w')
         except IOError as msg:
-            print(_("Failed to open output file '%s' : %s") % (opts.output, msg), file=sys.stderr)
+            print(_("Failed to open output file '%(filename)s' : %(error_msg)s") % {"filename": opts.output, "error_msg": msg}, file=sys.stderr)
             sys.exit(1)
     else:
         f = sys.stdout

--- a/tools/ksvalidator
+++ b/tools/ksvalidator
@@ -71,7 +71,7 @@ destdir = tempfile.mkdtemp("", "ksvalidator-tmp-", "/tmp")
 try:
     f = load_to_file(opts.ksfile, "%s/ks.cfg" % destdir)
 except KickstartError as e:
-    print(_("Error reading %s:\n%s") % (opts.ksfile, e))
+    print(_("Error reading %(filename)s:\n%(version)s") % {"filename": opts.ksfile, "version": e})
     cleanup(destdir)
 
 try:

--- a/tools/ksverdiff
+++ b/tools/ksverdiff
@@ -99,17 +99,17 @@ for cmd in sorted(bothSet):
     deprecatedOptList = getOptSet([cmd for cmd in toOpt if cmd.deprecated == 1])
 
     if len(newOptList) > 0:
-        print(_("The following options were added to the %s command in %s:") % (cmd, opts.t))
+        print(_("The following options were added to the %(command_name)s command in %(version)s:") % {"command_name": cmd, "version": opts.t})
         printList(sorted(newOptList))
         printed = True
 
     if len(deprecatedOptList) > 0:
-        print(_("The following options were deprecated from the %s command in %s:") % (cmd, opts.t))
+        print(_("The following options were deprecated from the %(command_name)s command in %(version)s:") % {"command_name": cmd, "version": opts.t})
         printList(sorted(deprecatedOptList))
         printed = True
 
     if len(removedOptList) > 0:
-        print(_("The following options were removed from the %s command in %s:") % (cmd, opts.t))
+        print(_("The following options were removed from the %(command_name)s command in %(version)s:") % {"command_name": cmd, "version": opts.t})
         printList(sorted(removedOptList))
         printed = True
 

--- a/translation-canary/.gitignore
+++ b/translation-canary/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+tests/pylint/.pylint.d

--- a/translation-canary/Makefile
+++ b/translation-canary/Makefile
@@ -1,0 +1,11 @@
+# This Makefile is just for running the tests
+
+all:
+	@echo "nothing to build"
+
+check:
+	PYTHONPATH=. tests/pylint/runpylint.py
+	python3 -m unittest discover tests/unittests
+
+ci:
+	$(MAKE) check

--- a/translation-canary/README.rst
+++ b/translation-canary/README.rst
@@ -1,0 +1,37 @@
+translation-canary
+-------------
+
+Translations can crash your program. Creating software for a wide audience
+means sending your strings away for translation, and giving up control of your
+strings means that strings with extralinguistic content can come back broken.
+No one is likely to even realize it until someone fires up your program in
+Hungarian and it crashes because Gtk bombed out on some busted markup, and the
+Hungarian speaker is sad, and you are sad, and everything is just the absolute
+worst.
+
+This is the canary in the translation coalmine.
+
+There are two parts to this project:
+
+translatable:
+  This contains checks on the strings to be submitted for translation. This
+  ensures that the content of the original strings marked for translation are
+  suitable for translation. These tests are run on the POT file before
+  uploading the POT or the updated PO files to the translators.
+
+translated:
+  This contains checks on the strings returned from the translators. This
+  ensures that the content of the translated strings won't break anything.
+  These tests are run on the source directory before creating a release.
+
+Both translatable and translated are run by running the module
+(e.g., `python3 -m translation_canary.translatable`) with the input file(s) as
+the argument.
+
+In addition to the python modules, this project contains xgettext_werror.sh, a
+wrapper for xgettext that treats warnings as errors.  xgettext will print
+warnings as it extracts translatable strings from source files, and these
+warnings should be addressed instead of silently ignored as they scroll by in
+the build output. To use the script in a package that uses the gettext template
+files from autopoint or gettextize, set XGETTEXT=/path/to/xgettext_werror.sh in
+Makevars.

--- a/translation-canary/tests/pylint/runpylint.py
+++ b/translation-canary/tests/pylint/runpylint.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import sys
+from pocketlint import PocketLintConfig, PocketLinter
+
+class TranslationCanaryLintConfig(PocketLintConfig):
+    @property
+    def disabledOptions(self):
+        return [ "W9930",           # Found interruptible system call %s
+                 "I0011",           # Locally disabling %s
+               ]
+
+    @property
+    def extraArgs(self):
+        return ["--init-import", "y"]
+
+if __name__ == "__main__":
+    conf = TranslationCanaryLintConfig()
+    linter = PocketLinter(conf)
+    rc = linter.run()
+    sys.exit(rc)

--- a/translation-canary/tests/unittests/test_translatable.py
+++ b/translation-canary/tests/unittests/test_translatable.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+import unittest
+from polib import POEntry
+
+from translation_canary.translatable.test_markup import test_markup
+from translation_canary.translatable.test_comment import test_comment
+
+class TestMarkup(unittest.TestCase):
+    def test_ok(self):
+        # no markup
+        test_markup(POEntry(msgid="test string"))
+
+        # internal markup
+        test_markup(POEntry(msgid="<b>test</b> string"))
+
+    def test_unnecessary_markup(self):
+        self.assertRaises(AssertionError, test_markup, POEntry(msgid="<b>test string</b>"))
+
+class TestComment(unittest.TestCase):
+    def test_ok(self):
+        # Perfectly fine string
+        test_comment(POEntry(msgid="Hello, I am a test string"))
+
+        # single-character string with a comment
+        test_comment(POEntry(msgid="c", comment="TRANSLATORS: 'c' to continue"))
+
+    def test_no_comment(self):
+        self.assertRaises(AssertionError, test_comment, POEntry(msgid="c"))

--- a/translation-canary/tests/unittests/test_translated.py
+++ b/translation-canary/tests/unittests/test_translated.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public # License and may only be used or replicated with the express permission of # Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+import unittest
+import tempfile
+import warnings
+import shutil
+import os
+import polib
+
+from translation_canary.translated.test_markup import test_markup
+from translation_canary.translated.test_percentage import test_percentage
+from translation_canary.translated.test_usability import test_usability
+
+# convert a polib.MOFile into a NamedTemporaryFile
+def mofile(moobj):
+    f = tempfile.NamedTemporaryFile(suffix='.mo')
+    moobj.save(f.name)
+    return f
+
+# convenience function for creating a single-entry mofile
+def mofile_from_entry(*args, **kwargs):
+    moobj = polib.MOFile()
+    moobj.append(polib.MOEntry(*args, **kwargs))
+    return mofile(moobj)
+
+class TestMarkup(unittest.TestCase):
+    # I know, pylint, that's the point
+    # pylint: disable=invalid-markup
+
+    def test_ok(self):
+        # no markup
+        with mofile_from_entry(msgid="test string", msgstr="estay ingstray") as m:
+            test_markup(m.name)
+
+        # matching markup
+        with mofile_from_entry(msgid="<b>bold</b> string", msgstr="<b>oldbay</b> ingstray") as m:
+            test_markup(m.name)
+
+        # matching plural
+        with mofile_from_entry(msgid="%d <b>bold</b> string", msgid_plural="%d <b>bold</b> strings",
+                msgstr_plural={0: "%d <b>oldbay</b> ingstray", 1: "%d <b>oldbay</b> instrays"}) as m:
+            test_markup(m.name)
+
+    def test_missing(self):
+        with mofile_from_entry(msgid="<b>bold</b> string", msgstr="oldbay ingstray") as m:
+            self.assertRaises(AssertionError, test_markup, m.name)
+
+    def test_mismatch(self):
+        with mofile_from_entry(msgid="<b>bold</b> string", msgstr="<i>oldbay</i> ingstray") as m:
+            self.assertRaises(AssertionError, test_markup, m.name)
+
+    def test_typo(self):
+        with mofile_from_entry(msgid="<b>bold</b> string", msgstr="<boldbay</b> ingstray") as m:
+            self.assertRaises(AssertionError, test_markup, m.name)
+
+    def test_mismatch_plural(self):
+        with mofile_from_entry(msgid="%d <b>bold</b> string", msgid_plural="%d <b>bold</b> strings",
+                msgstr_plural={0: "%d <b>olbday</b> ingstray", 1: "%d oldbay ingstrays"}) as m:
+            self.assertRaises(AssertionError, test_markup, m.name)
+
+    def test_invalid(self):
+        # Tags themselves are valid, but the XML is not
+        with mofile_from_entry(msgid="<b>bold</b> string", msgstr="<b/>oldbay</b> ingstray") as m:
+            self.assertRaises(AssertionError, test_markup, m.name)
+
+class TestPercentage(unittest.TestCase):
+    # test_percentage actually looks at .po files, so the tests need to create
+    # both a .po and a .mo in self.tmpdir
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.popath = os.path.join(self.tmpdir, "test.po")
+        self.mopath = os.path.join(self.tmpdir, "test.mo")
+
+        # Convert warnings into exceptions to make them easier to test for
+        warnings.simplefilter("error")
+        # polib throws a DeprecationWarnings so ignore that
+        warnings.simplefilter("default", DeprecationWarning)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        warnings.resetwarnings()
+
+    def test_ok(self):
+        # 100%
+        pofile = polib.POFile()
+        pofile.append(polib.POEntry(msgid="test string", msgstr="estay ingstray"))
+        pofile.save(self.popath)
+        pofile.save_as_mofile(self.mopath)
+        test_percentage(self.mopath)
+
+    def test_not_ok(self):
+        # 0%
+        pofile = polib.POFile()
+        pofile.append(polib.POEntry(msgid="test string", msgstr=""))
+        pofile.save(self.popath)
+        pofile.save_as_mofile(self.mopath)
+
+        self.assertRaises(Warning, test_percentage, self.mopath)
+
+class TestUsability(unittest.TestCase):
+    def test_ok(self):
+        # what lt's Plural-Forms is supposed to look like
+        moobj = polib.MOFile()
+        moobj.metadata["Plural-Forms"] = "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+
+        with mofile(moobj) as m:
+            test_usability(m.name)
+
+    def test_busted_plural_forms(self):
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1283599
+        moobj = polib.MOFile()
+        moobj.metadata["Plural-Forms"] = "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 or n%100>=20) ? 1 : 2)\n"
+
+        with mofile(moobj) as m:
+            self.assertRaises(Exception, test_usability, m.name)

--- a/translation-canary/translation_canary/translatable/__init__.py
+++ b/translation-canary/translation_canary/translatable/__init__.py
@@ -1,0 +1,85 @@
+# Framework for testing translatable strings
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+"""
+Framework for running tests against translatable strings.
+
+Tests are loaded from modules in this directory. A test is any callable object
+within the module with a name that starts with 'test_'.
+
+Each test is called with a POEntry object as an argument. A test passes if it
+returns without raising an exception.
+"""
+
+try:
+    import polib
+except ImportError:
+    print("You need to install the python-polib package to read translations")
+    raise
+
+# Gather tests from this directory
+import pkgutil
+_tests = []
+for finder, mod_name, _ispkg in pkgutil.iter_modules(__path__):
+    # Skip __main__
+    if mod_name == "__main__":
+        continue
+
+    # Load the module
+    module = finder.find_module(mod_name).load_module()
+
+    # Look for attributes that start with 'test_' and add them to the test list
+    for attrname, attr in module.__dict__.items():
+        if attrname.startswith('test_') and callable(attr):
+            _tests.append(attr)
+
+def testString(poentry):
+    """Run all tests against the given translatable string.
+
+       :param polib.POEntry poentry: The PO file entry to test
+       :returns: whether the tests succeeded or not
+       :rtype: bool
+    """
+    success = True
+    for test in _tests:
+        try:
+            test(poentry)
+        except Exception as e: # pylint: disable=broad-except
+            success = False
+            print("%s failed on %s: %s" % (test.__name__, poentry.msgid, str(e)))
+
+    return success
+
+def testPOT(potfile):
+    """Run all tests against all entries in a POT file.
+
+       :param str potfile: The name of a .pot file to test
+       :return: whether the checks succeeded or not
+       :rtype: bool
+    """
+    success = True
+
+    parsed_pot = polib.pofile(potfile)
+
+    for entry in parsed_pot:
+        if not testString(entry):
+            success = False
+
+    return success

--- a/translation-canary/translation_canary/translatable/__main__.py
+++ b/translation-canary/translation_canary/translatable/__main__.py
@@ -1,0 +1,33 @@
+# Entry point for testing translatable strings
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+import sys
+from . import testPOT
+
+if len(sys.argv) < 2:
+    print("Usage: translatable <POTfile>")
+    sys.exit(1)
+
+status = 0
+for potfile in sys.argv[1:]:
+    if not testPOT(potfile):
+        status = 1
+
+sys.exit(status)

--- a/translation-canary/translation_canary/translatable/test_comment.py
+++ b/translation-canary/translation_canary/translatable/test_comment.py
@@ -1,0 +1,26 @@
+# Check that a string that needs a comment has one
+# # Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+def test_comment(poentry):
+    # Single-character translatable strings (e.g., the 'c' of press c to
+    # continue) need some additional context in order to make sense. Make
+    # sure that they have it.
+
+    if len(poentry.msgid) == 1 and not poentry.comment:
+        raise AssertionError("Single-character string missing a comment.")

--- a/translation-canary/translation_canary/translatable/test_markup.py
+++ b/translation-canary/translation_canary/translatable/test_markup.py
@@ -1,0 +1,36 @@
+# Check that a string does not contain unnecessary Pango markup
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+from pocketlint.pangocheck import is_markup, markup_necessary
+import xml.etree.ElementTree as ET
+
+def test_markup(poentry):
+    # Unnecessary markup is markup applied to an entire string, such as
+    # _("<b>Bold Text</b>"). This could be instead be translated as
+    # "<b>%s</b>" % _("Bold Text"), and then the translator doesn't have to see
+    # the markup at all.
+
+    if is_markup(poentry.msgid):
+        # Wrap the string in <markup> nodes, parse it, test it
+        # The markup is unescaped on purpose
+        # pylint: disable=unescaped-markup
+        tree = ET.fromstring("<markup>%s</markup>" % poentry.msgid)
+        if not markup_necessary(tree):
+            raise AssertionError("Unnecessary markup")

--- a/translation-canary/translation_canary/translated/__init__.py
+++ b/translation-canary/translation_canary/translated/__init__.py
@@ -1,0 +1,144 @@
+# Framework for testing translations
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+"""
+Framework for running tests against translations.
+
+Tests are loaded from modules in this directory. A test is any callable object
+within the module with a name that starts with 'test_'.
+
+Each test is called with the name of .mo file to test as an argument. A test
+passes if it returns without raising an exception.
+"""
+
+import os, warnings
+
+_tests = []
+
+# Gather tests from this directory
+import pkgutil
+for finder, mod_name, _ispkg in pkgutil.iter_modules(__path__):
+    # Skip __main__
+    if mod_name == "__main__":
+        continue
+
+    # Load the module
+    module = finder.find_module(mod_name).load_module()
+
+    # Look for attributes that start with 'test_' and add them to the test list
+    for attrname, attr in module.__dict__.items():
+        if attrname.startswith('test_') and callable(attr):
+            _tests.append(attr)
+
+def _remove_lingua(linguas, language):
+    # Read in the LINGUAS file
+    with open(linguas, "rt") as f:
+        lingua_lines = f.readlines()
+
+    output_lines = []
+    for line in lingua_lines:
+        # Leave comments alone
+        if line.startswith('#'):
+            output_lines.append(line)
+            continue
+
+        # Split the line into a list of languages, remove the one we don't
+        # want, and put it back together
+        lingua_list = line.split()
+        lingua_list.remove(language)
+        output_lines.append(" ".join(lingua_list))
+
+    # Write LINGUAS back out
+    with open(linguas, "wt") as f:
+        f.writelines(output_lines)
+
+def testFile(mofile, prefix=None, releaseMode=False):
+    """Run all registered tests against the given .mo file.
+
+       If run in release mode, this function will always return true, and if
+       the mofile does not pass the tests the langauge will be removed.
+
+       :param str mofile: The .mo file name to check
+       :param str prefix: An optional directory prefix to strip from error messages
+       :return: whether the checks succeeded or not
+       :rtype: bool
+    """
+    success = True
+    for test in _tests:
+        # Don't print the tmpdir path in error messages
+        if prefix is not None and mofile.startswith(prefix):
+            moerror = mofile[len(prefix):]
+        else:
+            moerror = mofile
+
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                test(mofile)
+
+                # Print any warnings collected
+                for warn in w:
+                    print("%s warned on %s: %s" % (test.__name__, moerror, warn.message))
+        except Exception as e: # pylint: disable=broad-except
+            print("%s failed on %s: %s" % (test.__name__, moerror, str(e)))
+            if releaseMode:
+                # Remove the mo file and the po file it was built from
+                print("Removing %s" % mofile)
+                os.remove(mofile)
+
+                pofile = os.path.splitext(mofile)[0] + '.po'
+                print("Removing %s" % pofile)
+                os.remove(pofile)
+
+                # If there is a LINGUAS file in the po directory, remove the
+                # language from it
+                linguas = os.path.join(os.path.dirname(mofile), 'LINGUAS')
+                if os.path.exists(linguas):
+                    language = os.path.splitext(os.path.basename(mofile))[0]
+                    print("Removing %s from LINGUAS" % language)
+                    _remove_lingua(linguas, language)
+
+                # No need to run the rest of the tests since we just killed the file
+                break
+            else:
+                success = False
+
+    return success
+
+def testSourceTree(srcdir, releaseMode=False):
+    """Runs all registered tests against all .mo files in the given directory.
+
+       If run in release mode, this function will always return True and the
+       languages that do not pass the tests will be removed.
+
+       :param str srcdir: The path to the source directory to check
+       :param bool releaseMode: whether to run in release mode
+       :return: whether the checks succeeded or not
+       :rtype: bool
+    """
+    success = True
+    srcdir = os.path.normpath(srcdir)
+
+    for dirpath, _dirnames, paths in os.walk(srcdir):
+        for mofile in (os.path.join(dirpath, path) for path in paths
+                if path.endswith('.mo') or path.endswith('.gmo')):
+            if not testFile(mofile, prefix=srcdir + "/", releaseMode=releaseMode):
+                success = False
+
+    return success

--- a/translation-canary/translation_canary/translated/__main__.py
+++ b/translation-canary/translation_canary/translated/__main__.py
@@ -1,0 +1,39 @@
+# Entry point for testing translations
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+import sys, argparse
+from . import testSourceTree
+
+ap = argparse.ArgumentParser(description='Validate translated strings')
+ap.add_argument('--release', action='store_true', default=False,
+        help='Run in release mode')
+ap.add_argument('--test', dest='release', action='store_false',
+        help='Run in test mode')
+ap.add_argument('source_trees', metavar='SOURCE-TREE', nargs='+',
+        help='Source directory to test')
+
+args = ap.parse_args()
+
+status = 0
+for srcdir in args.source_trees:
+    if not testSourceTree(srcdir, args.release):
+        status = 1
+
+sys.exit(status)

--- a/translation-canary/translation_canary/translated/test_markup.py
+++ b/translation-canary/translation_canary/translated/test_markup.py
@@ -1,0 +1,62 @@
+# Check translations of pango markup
+#
+# This will look for translatable strings that appear to contain markup and
+# check that the markup in the translation matches.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+try:
+    import polib
+except ImportError:
+    print("You need to install the python-polib package to read translations")
+    raise
+
+from pocketlint.pangocheck import is_markup, markup_match
+import xml.etree.ElementTree as ET
+
+def test_markup(mofile):
+    mo = polib.mofile(mofile)
+
+    for entry in mo.translated_entries():
+        if is_markup(entry.msgid):
+            # If this is a plural, check each of the plural translations
+            if entry.msgid_plural:
+                xlations = entry.msgstr_plural
+            else:
+                xlations = {None: entry.msgstr}
+
+            for plural_id, msgstr in xlations.items():
+                # Check if the markup is valid at all
+                try:
+                    # pylint: disable=unescaped-markup
+                    ET.fromstring('<markup>%s</markup>' % msgstr)
+                except ET.ParseError:
+                    if entry.msgid_plural:
+                        raise AssertionError("Invalid markup translation for %d translation of msgid %s" %
+                                (plural_id, entry.msgid))
+                    else:
+                        raise AssertionError("Invalid markup translation for msgid %s" % entry.msgid)
+
+                # Check if the markup has the same number and kind of tags
+                if not markup_match(entry.msgid, msgstr):
+                    if entry.msgid_plural:
+                        raise AssertionError("Markup does not match for %d translation of msgid %s" %
+                                (plural_id, entry.msgid))
+                    else:
+                        raise AssertionError("Markup does not match for msgid %s" % entry.msgid)

--- a/translation-canary/translation_canary/translated/test_percentage.py
+++ b/translation-canary/translation_canary/translated/test_percentage.py
@@ -1,0 +1,42 @@
+# Check what percentage of strings a .mo translates
+#
+# This will reject translations that fall below a certain threshold of
+# translated strings.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+import os
+import warnings
+
+try:
+    import polib
+except ImportError:
+    print("You need to install the python-polib package to read translations")
+    raise
+
+threshold = 10
+
+def test_percentage(mofile):
+    # Open the .po file instead, which should be in the same location as the
+    # .mo file in the source archive
+    pofile = polib.pofile(os.path.splitext(mofile)[0] + '.po')
+    if pofile.percent_translated() < threshold:
+        # Issue a warning instead of an exception, since these should probably
+        # be handled on a case-by-case basis
+        warnings.warn("amount translated of %d%% below threshold of %d%%" % (pofile.percent_translated(), threshold))

--- a/translation-canary/translation_canary/translated/test_usability.py
+++ b/translation-canary/translation_canary/translated/test_usability.py
@@ -1,0 +1,28 @@
+# Check a .mo file for basic usability
+#
+# This will test that the file is well-formed and that the Plural-Forms value
+# is parseable
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+import gettext
+
+def test_usability(mofile):
+    with open(mofile, "rb") as fp:
+        _t = gettext.GNUTranslations(fp=fp)

--- a/translation-canary/xgettext_werror.sh
+++ b/translation-canary/xgettext_werror.sh
@@ -1,0 +1,46 @@
+#!/bin/sh -e
+#
+# xgettext_werror.sh: Run xgettext and actually do something with the warnings
+#
+# xgettext prints out warnings for certain problems in translatable strings,
+# such as format strings that cannot be translated due to position-based
+# parameters. These warnings generally indicate something that needs to be
+# addressed before the strings can be submitted for translation. This script
+# exits with a status of 1 so that the warnings are not ignored as they scroll
+# by in pages of build output.
+#
+# This script should be used in place of xgettext when rebuilding the .pot file,
+# e.g. by setting XGETTEXT in po/Makevars.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+returncode=0
+
+# Collect the output from xgettext. If xgettext fails, treat that as a failure
+# Make sure that "warning:" doesn't get translated
+xgettext_output="$(LC_MESSAGES=C xgettext "$@" 2>&1)" || returncode=$?
+
+# Look for warnings
+if echo "$xgettext_output" | fgrep -q "warning: "; then
+    returncode=1
+fi
+
+# Print the output and return
+echo "$xgettext_output"
+exit $returncode


### PR DESCRIPTION
I used --squash with the subtree add this time, so there's just one translation-canary commit (plus a merge) instead of all of them. I think I like that better and if no one disagrees I'll redo the other translation tests that before merging.

I did not modify the setup.py sdist command for this one since I realized while doing so that pykickstart needs to care about python2, and translation-canary is only python3. So I guess this is the model I'll be using for other setup.py projects.

A handful of format string problems, and lt.po has the same Plural-Forms error that blivet had ("or" instead of "||")