### PR TITLE
Fix class inheritance in RHEL6_VolGroup

### DIFF
--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -171,10 +171,10 @@ class FC16_VolGroup(FC3_VolGroup):
                       dest="reserved_percent", type="int", nargs=1, default=0)
         return op
 
-class RHEL6_VolGroup(FC3_VolGroup):
+class RHEL6_VolGroup(FC16_VolGroup):
     def parse(self, args):
         # first call the overriden method
-        retval = FC3_VolGroup.parse(self, args)
+        retval = FC16_VolGroup.parse(self, args)
 
         # the volgroup command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces

--- a/pykickstart/handlers/rhel6.py
+++ b/pykickstart/handlers/rhel6.py
@@ -103,6 +103,6 @@ class RHEL6Handler(BaseHandler):
         "RepoData": commands.repo.RHEL6_RepoData,
         "SshPwData": commands.sshpw.F13_SshPwData,
         "UserData": commands.user.F12_UserData,
-        "VolGroupData": commands.volgroup.FC3_VolGroupData,
+        "VolGroupData": commands.volgroup.FC16_VolGroupData,
         "ZFCPData": commands.zfcp.F12_ZFCPData,
     }

--- a/tests/commands/volgroup.py
+++ b/tests/commands/volgroup.py
@@ -7,7 +7,7 @@ class FC3_TestCase(CommandTest):
     command = "volgroup"
 
     def runTest(self):
-        if self.__class__ in (FC3_TestCase, F16_TestCase):
+        if self.__class__ in (FC3_TestCase, F16_TestCase, RHEL6_TestCase):
             def_pesize_str = " --pesize=32768"
         else:
             def_pesize_str = ""
@@ -52,18 +52,6 @@ class FC3_TestCase(CommandTest):
         self.assertEqual(cmd.__str__(), "vg.01")
 
 
-class RHEL6_TestCase(FC3_TestCase):
-    def runTest(self):
-        # extra test coverage
-        cmd = self.handler().commands[self.command]
-        cmd.parse(["volgroup", "vg.02", "pv.01"])
-        self.assertEqual(cmd.__str__(), "")
-        cmd.handler.autopart.seen = True
-        with self.assertRaises(KickstartParseError):
-            cmd.parse(["volgroup", "vg.02", "pv.01"])
-        cmd.handler.autopart.seen = False
-
-
 class FC3_Duplicate_TestCase(CommandSequenceTest):
     def runTest(self):
         self.assert_parse("""
@@ -78,7 +66,7 @@ class F16_TestCase(FC3_TestCase):
     def runTest(self):
         FC3_TestCase.runTest(self)
 
-        if self.__class__ in (FC3_TestCase, F16_TestCase):
+        if self.__class__ in (FC3_TestCase, F16_TestCase, RHEL6_TestCase):
             def_pesize_str = " --pesize=32768"
         else:
             def_pesize_str = ""
@@ -97,6 +85,20 @@ class F16_TestCase(FC3_TestCase):
         self.assert_parse_error("volgroup vg.01 pv.01 --reserved-space=-1", KickstartValueError)
         self.assert_parse_error("volgroup vg.01 pv.01 --reserved-percent=0", KickstartValueError)
         self.assert_parse_error("volgroup vg.01 pv.01 --reserved-percent=100", KickstartValueError)
+
+
+class RHEL6_TestCase(F16_TestCase):
+    def runTest(self):
+        F16_TestCase.runTest(self)
+        # extra test coverage
+        cmd = self.handler().commands[self.command]
+        cmd.parse(["volgroup", "vg.02", "pv.01"])
+        self.assertEqual(cmd.__str__(), "")
+        cmd.handler.autopart.seen = True
+        with self.assertRaises(KickstartParseError):
+            cmd.parse(["volgroup", "vg.02", "pv.01"])
+        cmd.handler.autopart.seen = False
+
 
 class F21_TestCase(F16_TestCase):
     def runTest(self):


### PR DESCRIPTION
https://github.com/rhinstaller/pykickstart/blob/master/pykickstart/commands/volgroup.py#L174

`RHEL6_VolGroup` should inherit from `FC16_VolGroup` so that it understands disk reservation.
