### PR TITLE
Use six.assertRaisesRegex to keep the tests working in python2.

### DIFF
--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -58,11 +58,7 @@ class ParserTest(unittest.TestCase):
         By default the KickstartParseError is expected.
         """
 
-        if not six.PY3:
-            assert_function = 'assertRaisesRegexp'
-        else:
-            assert_function = 'assertRaisesRegex'
-        with getattr(self, assert_function)(exception, regex):
+        with six.assertRaisesRegex(self, exception, regex):
             self.parser.readKickstartFromString(ks_string)
 
     def assert_parse(self, ks_string):
@@ -189,7 +185,7 @@ class CommandTest(unittest.TestCase):
         parser = self.getParser(inputStr)
         args = shlex.split(inputStr)
 
-        with self.assertRaisesRegex(exception, regex):
+        with six.assertRaisesRegex(self, exception, regex):
             parser.parse(args[1:])
 
     def assert_deprecated(self, cmd, opt):

--- a/tests/parser/include.py
+++ b/tests/parser/include.py
@@ -181,7 +181,7 @@ ls /tmp
 class Include_Bad_URL_TestCase(Include_URL_TestCase):
     def runTest(self):
         # Add some garbage to the end of the URL and ensure it breaks
-        self.assertRaisesRegex(KickstartError, "Error accessing URL",
+        six.assertRaisesRegex(self, KickstartError, "Error accessing URL",
                 self.parser.readKickstartFromString, self.ks % (self._url + "-garbage"))
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is so freaking dumb.