### PR TITLE
Add some initial static typing information to pykickstart.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ test:
 	@which nosetests || (echo "*** Please install nosetest (python-nose) ***"; exit 2)
 	@echo "*** Running unittests ***"
 	PYTHONPATH=. $(PYTHON) -m nose --processes=-1 $(NOSEARGS)
+	@which mypy || (echo "*** Please install mypy (python3-mypy) ***"; exit 2)
+	@echo "*** Running type checks ***"
+	PYTHONPATH=. mypy --use-python-path pykickstart
 
 coverage:
 	@which $(COVERAGE) || (echo "*** Please install coverage (python-coverage) ***"; exit 2)

--- a/pykickstart/commands/keyboard.py
+++ b/pykickstart/commands/keyboard.py
@@ -23,6 +23,12 @@ from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
 
+# import static typing information if available
+try:
+    from typing import Any  # pylint: disable=unused-import
+except ImportError:
+    pass
+
 class FC3_Keyboard(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
@@ -134,7 +140,7 @@ class F18_Keyboard(FC3_Keyboard):
 
     # property for backwards compatibility
     # pylint: disable=method-hidden
-    @property
+    @property   # type: ignore
     def keyboard(self):
         if self.x_layouts:
             return self._keyboard or self.vc_keymap or self.x_layouts[0]

--- a/pykickstart/commands/reqpart.py
+++ b/pykickstart/commands/reqpart.py
@@ -22,7 +22,8 @@ from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
 import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+# typeshed is missing the stub for ldgettext
+_ = lambda x: gettext.ldgettext("pykickstart", x)   # type: ignore
 
 class F23_ReqPart(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/handlers/control.py
+++ b/pykickstart/handlers/control.py
@@ -21,8 +21,15 @@ __all__ = ["commandMap", "dataMap"]
 
 from pykickstart import handlers
 
-commandMap = {}
-dataMap = {}
+# Import static typing information if available
+try:
+    from typing import Dict # pylint: disable=unused-import
+    from pykickstart.base import KickstartCommand, BaseData # pylint: disable=unused-import
+except ImportError:
+    pass
+
+commandMap = {} # type: Dict[int, Dict[str, KickstartCommand]]
+dataMap = {}    # type: Dict[int, Dict[str, BaseData]]
 
 if not commandMap:
     for (name, obj) in list(handlers.__dict__.items()):

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -29,7 +29,9 @@ This module exports two classes:
 """
 import warnings
 from copy import copy
-from optparse import Option, OptionError, OptionParser, OptionValueError
+# There are no type stubs written for optparse since it's deprecated, and mypy
+# complains about the actual module
+from optparse import Option, OptionError, OptionParser, OptionValueError    # type: ignore
 
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
 from pykickstart.version import versionToString

--- a/pykickstart/orderedset.py
+++ b/pykickstart/orderedset.py
@@ -4,7 +4,8 @@
 
 import collections
 
-class OrderedSet(collections.MutableSet):
+# Mypy can't find the class so just skip it
+class OrderedSet(collections.MutableSet):   # type: ignore
 
     def __init__(self, iterable=None):
         self.end = end = []

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -36,7 +36,9 @@ import os
 import six
 import shlex
 import sys
-from optparse import OptionParser
+# there are no type stubs for optparse, since argparse is the new hotness, and
+# mypy complains while parsing the actual module.
+from optparse import OptionParser   # type: ignore
 import warnings
 
 from pykickstart import constants, version


### PR DESCRIPTION
Add static typing information to the public methods on pykickstart.base
and pykickstart.version, since that seems like as good a place as any to
start, and any of the collection types where mypy needs type
annotations. Run mypy during 'make test' and add enough 'type: ignore'
comments to make it work.

All of the type information is specified as comments instead of using
the Python 3 type annotation syntax because pykickstart needs to be able
run as Python 2. The type comments are kind of gross in that they need
to be crammed all on to one line, but they seem a lot less likely to
make everything explode than the mypy codec provided as an alternative.

Fixed one actual type problem: pykickstart.base.BaseHandler initializes
currentLine as an int, but everywhere else this value is a string.
Initialize it to "" instead.