### PR TITLE
Use importlib to import modules.

### DIFF
--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -53,10 +53,7 @@ except ImportError:
     cast = lambda ty, val: val
 
 # mypy doesn't handle conditional imports, so just skip this part
-try:
-    from imputil import imp # type: ignore
-except ImportError: # Python 3
-    import imp              # type: ignore
+import importlib
 
 from pykickstart.i18n import _
 
@@ -192,18 +189,13 @@ def returnClassForVersion(version=DEVEL):   # type: (Union[int, str]) -> Callabl
         import pykickstart.handlers
         # mypy does not understand module.__path__, skip
         sys.path.extend(pykickstart.handlers.__path__)  # type: ignore
-        found = imp.find_module(module)
-        loaded = imp.load_module(module, found[0], found[1], found[2])
+        loaded = importlib.import_module(module)
 
         for (k, v) in list(loaded.__dict__.items()):
             if k.lower().endswith("%shandler" % module):
                 return v
     except:
-        found = None
         raise KickstartVersionError(_("Unsupported version specified: %s") % version)
-    finally: # Closing opened files in imp.load_module
-        if found and len(found) > 0:
-            found[0].close()
 
 def makeVersion(version=DEVEL): # type: (int) -> BaseHandler
     """Return a new instance of the syntax handler for version.  version can be

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -7,10 +7,7 @@ import warnings
 import re
 import six
 
-try:
-    from imputil import imp
-except ImportError: # Python 3
-    import imp
+import importlib
 
 from pykickstart.errors import KickstartParseError
 from pykickstart.parser import KickstartParser
@@ -244,27 +241,21 @@ def loadModules(moduleDir, cls_pattern="_TestCase", skip_list=None):
 
         # Attempt to load the found module.
         try:
-            try:
-                found = imp.find_module(module)
-                loaded = imp.load_module(module, found[0], found[1], found[2])
-            except ImportError as e:
-                print(_("Error loading module %s: %s") % (module, e))
-                found = None
-                continue
+            loaded = importlib.import_module(module)
+        except ImportError as e:
+            print(_("Error loading module %s: %s") % (module, e))
+            continue
 
-            # Find class names that match the supplied pattern (default: "_TestCase")
-            beforeCount = len(tests)
-            for obj in list(loaded.__dict__.keys()):
-                if obj.endswith(cls_pattern):
-                    tests.append(loaded.__dict__[obj])
-            afterCount = len(tests)
+        # Find class names that match the supplied pattern (default: "_TestCase")
+        beforeCount = len(tests)
+        for obj in list(loaded.__dict__.keys()):
+            if obj.endswith(cls_pattern):
+                tests.append(loaded.__dict__[obj])
+        afterCount = len(tests)
 
-            # Warn if no tests found
-            if beforeCount == afterCount:
-                print(_("Module %s does not contain any test cases; skipping.") % module)
-                continue
-        finally: # Closing opened files in imp.load_module
-            if found and len(found) > 0:
-                found[0].close()
+        # Warn if no tests found
+        if beforeCount == afterCount:
+            print(_("Module %s does not contain any test cases; skipping.") % module)
+            continue
 
     return tests

--- a/tests/version.py
+++ b/tests/version.py
@@ -308,24 +308,20 @@ class FailedImpImport_TestCase(CommandTest):
         try:
             # will force another import
             del sys.modules['pykickstart.version']
-            del sys.modules['imp']
-
-            # will cause ImportError
-            sys.modules['imputil'] = None
+            del sys.modules['importlib']
 
             import pykickstart.version as ver
             from pykickstart.handlers.f23 import F23Handler
 
             cls = ver.returnClassForVersion(ver.F23)
 
-            # assert the names; b/c of how the imp.load_module() works
+            # assert the names; b/c of how the importlib.import_module() works
             # asserting both classes being equal fails
             self.assertEqual(cls.__name__, F23Handler.__name__)
         finally:
             # force import to reload these modules
             del sys.modules['pykickstart.version']
-            del sys.modules['imp']
-            del sys.modules['imputil']
+            del sys.modules['importlib']
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Instead of choosing between two deprecated modules, use the one that is
in both Python 2.7 and Python 3.2+