### PR TITLE
Add support for --excludeWeakdeps option to %packages.

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -2319,6 +2319,12 @@ header:
 **Omitting the core group can produce a system that is not bootable or that
 cannot finish the install. Use with caution.**
 
+``--excludeWeakdeps``
+
+    Do not install packages from weak dependencies. These are packages linked
+    to the selected package set by Recommends and Supplements flags. By default
+    weak dependencies will be installed.
+
 
 Group-level options
 -------------------

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -345,6 +345,7 @@ class Packages(KickstartObject):
                             %packages section.
            instLangs     -- A list of languages to install.
            multiLib      -- Whether to use yum's "all" multilib policy.
+           excludeWeakdeps -- Whether to exclude weak dependencies.
            seen          -- If %packages was ever used in the kickstart file,
                             this attribute will be set to True.
 
@@ -363,6 +364,7 @@ class Packages(KickstartObject):
         self.packageList = []   # type: List[str]
         self.instLangs = None   # type: Union[None, List[str]]
         self.multiLib = False   # type: bool
+        self.excludeWeakdeps = False   # type: bool
         self.seen = False   # type: bool
 
     def __str__(self):  # type: (Packages) -> str
@@ -412,6 +414,8 @@ class Packages(KickstartObject):
             retval += " --instLangs=%s" % self.instLangs
         if self.multiLib:
             retval += " --multilib"
+        if self.excludeWeakdeps:
+            retval += " --excludeWeakdeps"
 
         if self._ver >= version.F8:
             return retval + "\n" + pkgs + "\n%end\n"

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -34,7 +34,7 @@ from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACE
                                   KS_MISSING_IGNORE, KS_MISSING_PROMPT
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
-from pykickstart.version import FC4, F7, F9, F18, F21, F22
+from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24
 
 from pykickstart.i18n import _
 
@@ -254,6 +254,7 @@ class PackageSection(Section):
         op.add_argument("--default", dest="defaultPackages", action="store_true", default=False, introduced=F7)
         op.add_argument("--instLangs", default=None, introduced=F9)
         op.add_argument("--multilib", dest="multiLib", action="store_true", default=False, introduced=F18)
+        op.add_argument("--excludeWeakdeps", dest="excludeWeakdeps", action="store_true", default=False, introduced=F24)
 
         ns = op.parse_args(args=args[1:], lineno=lineno)
 
@@ -277,4 +278,5 @@ class PackageSection(Section):
 
         self.handler.packages.nocore = ns.nocore
         self.handler.packages.multiLib = ns.multiLib
+        self.handler.packages.excludeWeakdeps = ns.excludeWeakdeps
         self.handler.packages.seen = True

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -198,6 +198,17 @@ class MultiLib_TestCase(DevelPackagesBase):
 
 %end""", str(pkgs).strip())
 
+class WeakDeps_TestCase(DevelPackagesBase):
+    def runTest(self):
+        DevelPackagesBase.runTest(self)
+
+        pkgs = Packages()
+        pkgs.default = True
+        pkgs.excludeWeakdeps = True
+        self.assertEqual("""%packages --default --excludeWeakdeps
+
+%end""", str(pkgs).strip())
+
 class GroupObj_TestCase(DevelPackagesBase):
     def runTest(self):
         self.assertLess(Group("A"), Group("B"))


### PR DESCRIPTION
This allows minimal installs, and reproducible ones, by not including
weak dependencies.

From https://bugzilla.redhat.com/show_bug.cgi?id=1331100