### PR TITLE
Add support for --excludeWeakdeps option to %packages.

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -2339,6 +2339,12 @@ header:
 
    **Omitting the core group can produce a system that is not bootable or that cannot finish the install. Use with caution.**
 
+``--excludeWeakdeps``
+
+    Do not install packages from weak dependencies. These are packages linked
+    to the selected package set by Recommends and Supplements flags. By default
+    weak dependencies will be installed.
+
 
 Group-level options
 -------------------

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -343,6 +343,7 @@ class Packages(KickstartObject):
                             %packages section.
            instLangs     -- A list of languages to install.
            multiLib      -- Whether to use yum's "all" multilib policy.
+           excludeWeakdeps -- Whether to exclude weak dependencies.
            seen          -- If %packages was ever used in the kickstart file,
                             this attribute will be set to True.
 
@@ -361,6 +362,7 @@ class Packages(KickstartObject):
         self.packageList = []   # type: List[str]
         self.instLangs = None   # type: Union[None, List[str]]
         self.multiLib = False   # type: bool
+        self.excludeWeakdeps = False   # type: bool
         self.seen = False   # type: bool
 
     def __str__(self):  # type: (Packages) -> str
@@ -410,6 +412,8 @@ class Packages(KickstartObject):
             retval += " --instLangs=%s" % self.instLangs
         if self.multiLib:
             retval += " --multilib"
+        if self.excludeWeakdeps:
+            retval += " --excludeWeakdeps"
 
         if ver >= version.F8:
             return retval + "\n" + pkgs + "\n%end\n"

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -34,7 +34,7 @@ from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACE
                                   KS_MISSING_IGNORE, KS_MISSING_PROMPT
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
-from pykickstart.version import FC4, F7, F9, F18, F21, F22
+from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24
 
 from pykickstart.i18n import _
 
@@ -266,6 +266,8 @@ class PackageSection(Section):
                       default=None, introduced=F9)
         op.add_option("--multilib", dest="multiLib", action="store_true",
                       default=False, introduced=F18)
+        op.add_option("--excludeWeakdeps", dest="excludeWeakdeps", action="store_true",
+                      default=False, introduced=F24)
 
         (opts, _extra) = op.parse_args(args=args[1:], lineno=lineno)
 
@@ -289,4 +291,5 @@ class PackageSection(Section):
 
         self.handler.packages.nocore = opts.nocore
         self.handler.packages.multiLib = opts.multiLib
+        self.handler.packages.excludeWeakdeps = opts.excludeWeakdeps
         self.handler.packages.seen = True

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -384,5 +384,14 @@ class Packages_Empty_TestCase(ParserTest):
             self.assertTrue(self.handler.packages.seen)
             self.assertEqual(str(self.handler.packages).strip(), "%packages\n\n%end")
 
+class WeakDeps_TestCase(DevelPackagesBase):
+    def runTest(self):
+        pkgs = Packages()
+        pkgs.default = True
+        pkgs.excludeWeakdeps = True
+        self.assertEqual("""%packages --default --excludeWeakdeps
+
+%end""", str(pkgs).strip())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This allows minimal installs, and reproducible ones, by not including
weak dependencies.

This is a pykickstart-2 port of https://github.com/rhinstaller/pykickstart/pull/78