### PR TITLE
Adapt to the new version of mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ coverage:
 	$(COVERAGE) report -m | tee coverage-report.log
 	@which mypy || (echo "*** Please install mypy (python3-mypy) ***"; exit 2)
 	@echo "*** Running type checks ***"
-	PYTHONPATH=. mypy --use-python-path pykickstart
+	PYTHONPATH=. mypy pykickstart
 
 clean:
 	-rm *.tar.gz pykickstart/*.pyc pykickstart/*/*.pyc tests/*.pyc tests/*/*.pyc docs/programmers-guide *log .coverage

--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -47,22 +47,15 @@ from pykickstart.ko import KickstartObject
 from pykickstart.version import versionToString
 from pykickstart.parser import Packages
 
-# import static typing information if avaialble
-try:
-    from typing import Union, Any, List, Dict   # pylint: disable=unused-import
-    from pykickstart.parser import Script       # pylint: disable=unused-import
-except ImportError:                             # pragma: no cover
-    pass
-
 ###
 ### COMMANDS
 ###
 class KickstartCommand(KickstartObject):
     """The base class for all kickstart commands.  This is an abstract class."""
-    removedKeywords = []    # type: List[str]
-    removedAttrs = []       # type: List[str]
+    removedKeywords = []
+    removedAttrs = []
 
-    def __init__(self, writePriority=0, *args, **kwargs):   # type: (KickstartCommand, Union[None, int], *Any, **Any) -> None
+    def __init__(self, writePriority=0, *args, **kwargs):
         """Create a new KickstartCommand instance.  This method must be
            provided by all subclasses, but subclasses must call
            KickstartCommand.__init__ first.  Instance attributes:
@@ -97,7 +90,7 @@ class KickstartCommand(KickstartObject):
         # These will be set by the dispatcher.
         self.currentCmd = ""
         self.currentLine = ""
-        self.handler = None     # type: Union[None, BaseHandler]
+        self.handler = None
         self.lineno = 0
         self.seen = False
 
@@ -108,7 +101,7 @@ class KickstartCommand(KickstartObject):
         for arg in (kw for kw in self.removedKeywords if kw in kwargs):
             kwargs.pop(arg)
 
-    def __call__(self, *args, **kwargs):    # type: (KickstartCommand, *Any, **Any) -> None
+    def __call__(self, *args, **kwargs):
         """Set multiple attributes on a subclass of KickstartCommand at once
            via keyword arguments.  Valid attributes are anything specified in
            a subclass, but unknown attributes will be ignored.
@@ -131,14 +124,14 @@ class KickstartCommand(KickstartObject):
         return KickstartObject.__str__(self)
 
     # pylint: disable=unused-argument
-    def parse(self, args):  # type: (KickstartCommand, List[str]) -> Union[None, BaseData, KickstartCommand]
+    def parse(self, args):
         """Parse the list of args and set data on the KickstartCommand object.
            This method must be provided by all subclasses.
         """
         raise TypeError("parse() not implemented for KickstartCommand")
     # pylint: enable=unused-argument
 
-    def dataList(self):     # type: (KickstartCommand) -> List[BaseData]
+    def dataList(self):
         """For commands that can occur multiple times in a single kickstart
            file (like network, part, etc.), return the list that we should
            append more data objects to.
@@ -154,7 +147,7 @@ class KickstartCommand(KickstartObject):
         """
         return None
 
-    def deleteRemovedAttrs(self):   # type: (KickstartCommand) -> None
+    def deleteRemovedAttrs(self):
         """Remove all attributes from self that are given in the removedAttrs
            list.  This method should be called from __init__ in a subclass,
            but only after the superclass's __init__ method has been called.
@@ -197,7 +190,7 @@ class DeprecatedCommand(KickstartCommand):
        only specifying an __init__ method that calls the superclass's __init__.
        This is an abstract class.
     """
-    def __init__(self, writePriority=None, *args, **kwargs):    # type: (DeprecatedCommand, Union[None, int], *Any, **Any) -> None
+    def __init__(self, writePriority=None, *args, **kwargs):
         # We don't want people using this class by itself.
         if self.__class__ is DeprecatedCommand:
             raise TypeError("DeprecatedCommand is an abstract class.")
@@ -209,7 +202,7 @@ class DeprecatedCommand(KickstartCommand):
         """Placeholder since DeprecatedCommands don't work anymore."""
         return ""
 
-    def parse(self, args):      # type: (DeprecatedCommand, List[str]) -> Union[None, BaseData, KickstartCommand]
+    def parse(self, args):
         """Print a warning message if the command is seen in the input file."""
         mapping = {"lineno": self.lineno, "cmd": self.currentCmd}
         warnings.warn(_("Ignoring deprecated command on line %(lineno)s:  The %(cmd)s command has been deprecated and no longer has any effect.  It may be removed from future releases, which will result in a fatal error from kickstart.  Please modify your kickstart file to remove this command.") % mapping, DeprecationWarning)
@@ -227,10 +220,10 @@ class BaseHandler(KickstartObject):
                   a class attribute of a BaseHandler subclass and is used to
                   set up the command dict.  It is for read-only use.
     """
-    version = None      # type: Union[None, int]
+    version = None
 
     def __init__(self, mapping=None, dataMapping=None, commandUpdates=None,
-            dataUpdates=None, *args, **kwargs):    # type: (BaseHandler, Union[Dict[str, KickstartCommand], None], Union[Dict[str, BaseData], None], Union[Dict[str, KickstartCommand], None], Union[Dict[str, BaseData], None], *Any, **Any) -> None
+            dataUpdates=None, *args, **kwargs):
         """Create a new BaseHandler instance.  This method must be provided by
            all subclasses, but subclasses must call BaseHandler.__init__ first.
 
@@ -280,19 +273,19 @@ class BaseHandler(KickstartObject):
 
         # This isn't really a good place for these, but it's better than
         # everything else I can think of.
-        self.scripts = []   # type: List[Script]
-        self.packages = Packages()  # type: Packages
+        self.scripts = []
+        self.packages = Packages()
         self.platform = ""
 
         # These will be set by the dispatcher.
-        self.commands = {}  # type: Dict[str, KickstartCommand]
+        self.commands = {}
         self.currentLine = ""
 
         # A dict keyed by an integer priority number, with each value being a
         # list of KickstartCommand subclasses.  This dict is maintained by
         # registerCommand and used in __str__.  No one else should be touching
         # it.
-        self._writeOrder = {}   # type: Dict[int, List[KickstartCommand]]
+        self._writeOrder = {}
 
         self._registerCommands(mapping, dataMapping, commandUpdates, dataUpdates)
 
@@ -417,7 +410,7 @@ class BaseHandler(KickstartObject):
         for (dataName, dataClass) in list(dMap.items()):
             setattr(self, dataName, dataClass)
 
-    def resetCommand(self, cmdName):    # type: (BaseHandler, str) -> None
+    def resetCommand(self, cmdName):
         """Given the name of a command that's already been instantiated, create
            a new instance of it that will take the place of the existing
            instance.  This is equivalent to quickly blanking out all the
@@ -429,13 +422,13 @@ class BaseHandler(KickstartObject):
             raise KeyError
 
         # mypy does not understand this, so ignore it for now
-        cmdObj = self.commands[cmdName].__class__() # type: ignore
+        cmdObj = self.commands[cmdName].__class__()
 
         self._setCommand(cmdObj)
         self.commands[cmdName] = cmdObj
         self.commands[cmdName].handler = self
 
-    def dispatcher(self, args, lineno): # type: (BaseHandler, List[str], int) -> Union[BaseData, KickstartCommand]
+    def dispatcher(self, args, lineno):
         """Call the appropriate KickstartCommand handler for the current line
            in the kickstart file.  A handler for the current command should
            be registered, though a handler of None is not an error.  Returns
@@ -469,7 +462,7 @@ class BaseHandler(KickstartObject):
 
             return obj
 
-    def maskAllExcept(self, lst):   # type: (BaseHandler, List[str]) -> None
+    def maskAllExcept(self, lst):
         """Set all entries in the commands dict to None, except the ones in
            the lst.  All other commands will not be processed.
         """
@@ -479,7 +472,7 @@ class BaseHandler(KickstartObject):
             if not key in lst:
                 self.commands[key] = None
 
-    def hasCommand(self, cmd):      # type: (BaseHandler, str) -> bool
+    def hasCommand(self, cmd):
         """Return true if there is a handler for the string cmd."""
         return hasattr(self, cmd)
 
@@ -488,10 +481,10 @@ class BaseHandler(KickstartObject):
 ###
 class BaseData(KickstartObject):
     """The base class for all data objects.  This is an abstract class."""
-    removedKeywords = []    # type: List[str]
-    removedAttrs = []       # type: List[str]
+    removedKeywords = []
+    removedAttrs = []
 
-    def __init__(self, *args, **kwargs):    # type: (BaseData, *Any, **Any) -> None
+    def __init__(self, *args, **kwargs):
         """Create a new BaseData instance.
 
            lineno -- Line number in the ks-file where this object was defined
@@ -508,7 +501,7 @@ class BaseData(KickstartObject):
         """Return a string formatted for output to a kickstart file."""
         return ""
 
-    def __call__(self, *args, **kwargs):    # type: (BaseData, *Any, **Any) -> None
+    def __call__(self, *args, **kwargs):
         """Set multiple attributes on a subclass of BaseData at once via
            keyword arguments.  Valid attributes are anything specified in a
            subclass, but unknown attributes will be ignored.
@@ -522,7 +515,7 @@ class BaseData(KickstartObject):
             if hasattr(self, key):
                 setattr(self, key, val)
 
-    def deleteRemovedAttrs(self):   # type: (BaseData) -> None
+    def deleteRemovedAttrs(self):
         """Remove all attributes from self that are given in the removedAttrs
            list.  This method should be called from __init__ in a subclass,
            but only after the superclass's __init__ method has been called.

--- a/pykickstart/base.pyi
+++ b/pykickstart/base.pyi
@@ -1,0 +1,84 @@
+# type stubs for pykickstart.base
+#
+# David Shea <dshea@redhat.com>
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc. 
+#
+
+from typing import Optional, Union, Any, List, Dict
+
+from pykickstart.ko import KickstartObject
+from pykickstart.parser import Script, Packages
+from argparse import Namespace
+
+class KickstartCommand(KickstartObject):
+    # class attributes
+    removedKeywords = ...       # type: List[str]
+    removedAttrs = ...          # type: List[str]
+
+    # instance attributes
+    currentCmd = ...            # type: str
+    currentLine = ...           # type: str
+    handler = ...               # type: Optional[BaseHandler]
+    lineno = ...                # type: int
+    seen = ...                  # type: bool
+
+    def __init__(self, writePriority: int, *args: Any, **kwargs: Any) -> None: ...
+
+    def parse(self, args: List[str]) -> Optional[Union[BaseData, KickstartCommand]]: ...
+    def dataList(self) -> List[BaseData]: ...
+    
+    @property
+    def dataClass(self) -> Optional[BaseData]: ...
+
+    def deleteRemovedAttrs(self) -> None: ...
+    def set_to_self(self, namespace: Namespace) -> None: ...
+    def set_to_obj(self, namespace: Namespace, obj: Any) -> None: ...
+
+class BaseHandler(KickstartObject):
+    # class attributes
+    version = ...               # type: Optional[int]
+
+    # instance attributes
+    scripts = ...               # type: List[Script]
+    packages = ...              # type: Packages
+    platform = ...              # type: str
+    commands = ...              # type: Dict[str, KickstartCommand]
+    currentLine = ...           # type: str
+
+    def __init__(self,
+                 mapping: Dict[str, KickstartCommand] = None,
+                 dataMapping: Dict[str, BaseData] = None,
+                 commandUpdates: Dict[str, KickstartCommand] = None,
+                 dataUpdates: Dict[str, BaseData] = None,
+                 *args: Any,
+                 **kargs: Any) -> None: ...
+
+    def resetCommand(self, cmdName: str) -> None: ...
+    def dispatcher(self, args: List[str], lineno: int) -> Optional[KickstartCommand]: ...
+    def maskAllExcept(self, lst: List[str]) -> None: ...
+
+class DeprecatedCommand(KickstartCommand):
+    pass
+
+class BaseData(KickstartObject):
+    # class attributes
+    removedKeywords = ...       # type: List[str]
+    removedAttrs = ...          # type: List[str]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+    def deleteRemovedAttrs(self) -> None: ...

--- a/pykickstart/handlers/control.pyi
+++ b/pykickstart/handlers/control.pyi
@@ -1,7 +1,8 @@
+# type stubs for pykickstart.handlers.control
 #
-# Chris Lumens <clumens@redhat.com>
+# David Shea <dshea@redhat.com>
 #
-# Copyright 2007-2014 Red Hat, Inc.
+# Copyright 2016 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use, modify,
 # copy, or redistribute it subject to the terms and conditions of the GNU
@@ -17,24 +18,10 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc. 
 #
-__all__ = ["commandMap", "dataMap"]
 
-from pykickstart import handlers
+from typing import Dict
 
-commandMap = {}
-dataMap = {}
+from pykickstart.base import KickstartCommand, BaseData
 
-if not commandMap:
-    for (name, obj) in list(handlers.__dict__.items()):
-        if not (name.startswith("fc") or name.startswith("f") or name.startswith("rhel")):
-            continue
-
-        if not obj.__all__ or not obj.__all__[0].endswith("Handler"):
-            continue
-
-        # Now we've got a WhateverHandler module in obj.  This module should
-        # export one class named WhateverHandler, which we can get at indirectly
-        # through __all__, like so:
-        handler = obj.__dict__[obj.__all__[0]]
-        commandMap[handler.version] = handler.commandMap
-        dataMap[handler.version] = handler.dataMap
+commandMap = ... # type: Dict[int, Dict[str, KickstartCommand]]
+dataMap = ...    # type: Dict[int, Dict[str, BaseData]]

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -37,7 +37,7 @@ import six
 import shlex
 import sys
 import warnings
-from ordered_set import OrderedSet  # type: ignore
+from ordered_set import OrderedSet
 
 from pykickstart import constants, version
 from pykickstart.errors import KickstartError, KickstartParseError, formatErrorMsg
@@ -49,16 +49,6 @@ from pykickstart.sections import PackageSection, PreScriptSection, PreInstallScr
                                  NullSection
 
 from pykickstart.i18n import _
-
-# import static typing information if available
-# pylint: disable=unused-import
-try:
-    from typing import Any, Callable, List, Union
-    from pykickstart.base import BaseData, BaseHandler, KickstartCommand
-    from pykickstart.sections import Section
-except ImportError:
-    pass
-# pylint: enable=unused-import
 
 STATE_END = "end"
 STATE_COMMANDS = "commands"
@@ -110,7 +100,7 @@ def _preprocessStateMachine (lineIter):
 
     return retval
 
-def preprocessFromStringToString (s):   # type: (str) -> str
+def preprocessFromStringToString (s):
     """Preprocess the kickstart file, provided as the string s.  This
        method is currently only useful for handling %ksappend lines, which
        need to be fetched before the real kickstart parser can be run.
@@ -119,7 +109,7 @@ def preprocessFromStringToString (s):   # type: (str) -> str
     i = iter(s.splitlines(True) + [""])
     return _preprocessStateMachine(i)
 
-def preprocessKickstartToString (f):    # type: (bytes) -> str
+def preprocessKickstartToString (f):
     """Preprocess the kickstart file, given by the filename f.  This
        method is currently only useful for handling %ksappend lines,
        which need to be fetched before the real kickstart parser can be
@@ -200,7 +190,7 @@ class Script(KickstartObject):
        provided, most of the attributes of Script have to do with running the
        script.  Instances of Script are held in a list by the Version object.
     """
-    def __init__(self, script, *args , **kwargs):   # type: (Script, str, *Any, **Any) -> None
+    def __init__(self, script, *args , **kwargs):
         """Create a new Script instance.  Instance attributes:
 
            :keyword errorOnFail: If execution of the script fails, should anaconda
@@ -225,12 +215,12 @@ class Script(KickstartObject):
         KickstartObject.__init__(self, *args, **kwargs)
         self.script = "".join(script)
 
-        self.interp = kwargs.get("interp", "/bin/sh")   # type: str
-        self.inChroot = kwargs.get("inChroot", False)   # type: Union[None, bool]
-        self.lineno = kwargs.get("lineno", None)    # type: Union[None, int]
-        self.logfile = kwargs.get("logfile", None)  # type: Union[None, str]
-        self.errorOnFail = kwargs.get("errorOnFail", False) # type: Union[None, bool]
-        self.type = kwargs.get("type", constants.KS_SCRIPT_PRE) # type: int
+        self.interp = kwargs.get("interp", "/bin/sh")
+        self.inChroot = kwargs.get("inChroot", False)
+        self.lineno = kwargs.get("lineno", None)
+        self.logfile = kwargs.get("logfile", None)
+        self.errorOnFail = kwargs.get("errorOnFail", False)
+        self.type = kwargs.get("type", constants.KS_SCRIPT_PRE)
 
     def __str__(self):
         """Return a string formatted for output to a kickstart file."""
@@ -272,7 +262,7 @@ class Script(KickstartObject):
 ##
 class Group(KickstartObject):
     """A class representing a single group in the %packages section."""
-    def __init__(self, name="", include=constants.GROUP_DEFAULT):   # type: (Group, str, int) -> None
+    def __init__(self, name="", include=constants.GROUP_DEFAULT):
         """Create a new Group instance.  Instance attributes:
 
            name    -- The group's identifier
@@ -316,7 +306,7 @@ class Packages(KickstartObject):
     _ver = version.DEVEL
 
     """A class representing the %packages section of the kickstart file."""
-    def __init__(self, *args, **kwargs):    # type: (Packages, *Any, **Any) -> None
+    def __init__(self, *args, **kwargs):
         """Create a new Packages instance.  Instance attributes:
 
            addBase       -- Should the Base group be installed even if it is
@@ -352,22 +342,22 @@ class Packages(KickstartObject):
         """
         KickstartObject.__init__(self, *args, **kwargs)
 
-        self.addBase = True # type: bool
-        self.nocore = False # type: bool
-        self.default = False    # type: bool
-        self.environment = None # type: Union[None, str]
-        self.excludedList = []  # type: List[str]
-        self.excludedGroupList = [] # type: List[Group]
-        self.excludeDocs = False    # type: bool
-        self.groupList = [] # type: List[Group]
-        self.handleMissing = constants.KS_MISSING_PROMPT    # type: int
-        self.packageList = []   # type: List[str]
-        self.instLangs = None   # type: Union[None, List[str]]
-        self.multiLib = False   # type: bool
-        self.excludeWeakdeps = False   # type: bool
-        self.seen = False   # type: bool
+        self.addBase = True
+        self.nocore = False
+        self.default = False
+        self.environment = None
+        self.excludedList = []
+        self.excludedGroupList = []
+        self.excludeDocs = False
+        self.groupList = []
+        self.handleMissing = constants.KS_MISSING_PROMPT
+        self.packageList = []
+        self.instLangs = None
+        self.multiLib = False
+        self.excludeWeakdeps = False
+        self.seen = False
 
-    def __str__(self):  # type: (Packages) -> str
+    def __str__(self):
         """Return a string formatted for output to a kickstart file."""
         pkgs = ""
 
@@ -422,7 +412,7 @@ class Packages(KickstartObject):
         else:
             return retval + "\n" + pkgs + "\n"
 
-    def _processGroup (self, line): # type: (Packages, str) -> None
+    def _processGroup (self, line):
         op = KSOptionParser()
         op.add_argument("--nodefaults", action="store_true", default=False)
         op.add_argument("--optional", action="store_true", default=False)
@@ -446,7 +436,7 @@ class Packages(KickstartObject):
         else:
             self.groupList.append(Group(name=grp, include=constants.GROUP_DEFAULT))
 
-    def add (self, pkgList):    # type: (Packages, List[str]) -> None
+    def add (self, pkgList):
         """Given a list of lines from the input file, strip off any leading
            symbols and add the result to the appropriate list.
         """
@@ -493,8 +483,8 @@ class Packages(KickstartObject):
         existingExcludedSet = (existingExcludedSet - existingPackageSet) | newExcludedSet
 
         # FIXME: figure these types out
-        self.packageList = list(existingPackageSet) # type: ignore
-        self.excludedList = list(existingExcludedSet)   # type: ignore
+        self.packageList = list(existingPackageSet)
+        self.excludedList = list(existingExcludedSet)
 
 ###
 ### PARSER
@@ -507,7 +497,7 @@ class KickstartParser(object):
        overridden.
     """
     def __init__ (self, handler, followIncludes=True, errorsAreFatal=True,
-                  missingIncludeIsFatal=True, unknownSectionIsFatal=True):  # type: (KickstartParser, BaseHandler, bool, bool, bool, bool) -> None
+                  missingIncludeIsFatal=True, unknownSectionIsFatal=True):
         """Create a new KickstartParser instance.  Instance attributes:
 
            errorsAreFatal        -- Should errors cause processing to halt, or
@@ -531,7 +521,7 @@ class KickstartParser(object):
         self.errorsAreFatal = errorsAreFatal
         self.followIncludes = followIncludes
         self.handler = handler
-        self.currentdir = {}    # type: Dict[int, str]
+        self.currentdir = {}
         self.missingIncludeIsFatal = missingIncludeIsFatal
         self.unknownSectionIsFatal = unknownSectionIsFatal
 
@@ -543,21 +533,21 @@ class KickstartParser(object):
         Script._ver = self.version
         Packages._ver = self.version
 
-        self._sections = {} # type: Dict[str, Section]
+        self._sections = {}
         self.setupSections()
 
-    def _reset(self):   # type: (KickstartParser) -> None
+    def _reset(self):
         """Reset the internal variables of the state machine for a new kickstart file."""
         self._state = STATE_COMMANDS
         self._includeDepth = 0
 
-    def getSection(self, s):    # type: (KickstartParser, str) -> Section
+    def getSection(self, s):
         """Return a reference to the requested section (s must start with '%'s),
            or raise KeyError if not found.
         """
         return self._sections[s]
 
-    def handleCommand (self, lineno, args): # type: (KickstartParser, int, List[str]) -> Union[BaseData, KickstartCommand]
+    def handleCommand (self, lineno, args):
         """Given the list of command and arguments, call the Version's
            dispatcher method to handle the command.  Returns the command or
            data object returned by the dispatcher.  This method may be
@@ -568,7 +558,7 @@ class KickstartParser(object):
             retval = self.handler.dispatcher(args, lineno)
             return retval
 
-    def registerSection(self, obj): # type: (KickstartParser, Section) -> None
+    def registerSection(self, obj):
         """Given an instance of a Section subclass, register the new section
            with the parser.  Calling this method means the parser will
            recognize your new section and dispatch into the given object to
@@ -582,7 +572,7 @@ class KickstartParser(object):
 
         self._sections[obj.sectionOpen] = obj
 
-    def _finalize(self, obj):   # type: (KickstartParser, Section) -> None
+    def _finalize(self, obj):
         """Called at the close of a kickstart section to take any required
            actions.  Internally, this is used to add scripts once we have the
            whole body read.
@@ -590,7 +580,7 @@ class KickstartParser(object):
         obj.finalize()
         self._state = STATE_COMMANDS
 
-    def _handleSpecialComments(self, line): # type: (KickstartParser, str) -> None
+    def _handleSpecialComments(self, line):
         """Kickstart recognizes a couple special comments."""
         if self._state != STATE_COMMANDS:
             return
@@ -664,7 +654,7 @@ class KickstartParser(object):
 
         return lineno
 
-    def _validState(self, st):  # type: (KickstartParser, str) -> bool
+    def _validState(self, st):
         """Is the given section tag one that has been registered with the parser?"""
         return st in list(self._sections.keys())
 
@@ -681,10 +671,10 @@ class KickstartParser(object):
             else:
                 print(msg)
 
-    def _isBlankOrComment(self, line):  # type: (KickstartParser, str) -> bool
+    def _isBlankOrComment(self, line):
         return line.isspace() or line == "" or line.lstrip()[0] == '#'
 
-    def _handleInclude(self, f):    # type: (KickstartParser, str) -> None
+    def _handleInclude(self, f):
         # This case comes up primarily in ksvalidator.
         if not self.followIncludes:
             return
@@ -702,7 +692,7 @@ class KickstartParser(object):
 
         self._includeDepth -= 1
 
-    def _stateMachine(self, lineIter):  # type: (KickstartParser, PutBackIterator) -> None
+    def _stateMachine(self, lineIter):
         # For error reporting.
         lineno = 0
 
@@ -770,7 +760,7 @@ class KickstartParser(object):
                 lineno -= 1
                 lineno = self._readSection(lineIter, lineno)
 
-    def readKickstartFromString (self, s, reset=True):  # type: (KickstartParser, str, bool) -> None
+    def readKickstartFromString (self, s, reset=True):
         """Process a kickstart file, provided as the string str."""
         if reset:
             self._reset()
@@ -781,7 +771,7 @@ class KickstartParser(object):
         i = PutBackIterator(s.splitlines(True) + [""])
         self._stateMachine (i)
 
-    def readKickstart(self, f, reset=True): # type: (KickstartParser, str, bool) -> None
+    def readKickstart(self, f, reset=True):
         """Process a kickstart file, given by the filename f."""
         if reset:
             self._reset()
@@ -808,7 +798,7 @@ class KickstartParser(object):
 
         self.readKickstartFromString(s, reset=False)
 
-    def setupSections(self):    # type: (KickstartParser) -> None
+    def setupSections(self):
         """Install the sections all kickstart files support.  You may override
            this method in a subclass, but should avoid doing so unless you know
            what you're doing.

--- a/pykickstart/parser.pyi
+++ b/pykickstart/parser.pyi
@@ -1,0 +1,91 @@
+# type stubs for pykickstart.parser
+#
+# David Shea <dshea@redhat.com>
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc. 
+#
+
+from typing import Union, Optional, Any, List, Dict
+
+from pykickstart.ko import KickstartObject
+from pykickstart.base import BaseHandler, KickstartCommand, BaseData
+from pykickstart.sections import Section
+
+def preprocessFromStringToString(s: str) -> str: ...
+def preprocessKickstartToString(f: str) -> str: ...
+def preprocessFromString(s: str) -> str: ...
+def preprocessKickstart(f: str) -> Optional[str]: ... 
+
+class Script(KickstartObject):
+    # instance attributes
+    script = ...        # type: str
+    interp = ...        # type: str
+    lineno = ...        # type: Optional[str]
+    logfile = ...       # type: Optional[str]
+    errorOnFail = ...   # type: bool
+    typee = ...         # type: int
+
+    def __init__(self, script: str, *args: Any, **kwargs: Any) -> None: ...
+
+class Group(KickstartObject):
+    # instance attributes
+    name = ...          # type: str
+    include = ...       # type: int
+
+    def __init__(self, name: str = ..., include: int = ...) -> None: ...
+
+class Packages(KickstartObject):
+    # instance attributes
+    addBase = ...           # type: bool
+    nocore = ...            # type: bool
+    default = ...           # type: bool
+    environment = ...       # type: Optional[str]
+    excludedList = ...      # type: List[str]
+    exlucdedGroupList = ... # type: List[Group]
+    excludeDocs = ...       # type: bool
+    groupList = ...         # type: List[Group]
+    handleMissing = ...     # type: int
+    packageList = ...       # type: List[str]
+    instLangs = ...         # type: Optional[List[str]]
+    multiLib = ...          # type: bool
+    excludeWeakdeps = ...   # type: bool
+    seen = ...              # type: bool
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+    def add(self, pkgList: List[str]) -> None: ...
+
+class KickstartParser(object):
+    # instance attributes
+    errorsAreFatal = ...        # type: bool
+    followIncludes = ...        # type: bool
+    handler = ...               # type: BaseHandler
+    currentdir = ...            # type: Dict[int, str]
+    missingIncludeIsFatal = ... # type: bool
+    unknownSectionIsFatal = ... # type: bool
+    version = ...               # type: int
+
+    def __init__(self, handler: BaseHandler,
+                 followIncludes: bool = ..., errorsAreFatal: bool = ...,
+                 missingIncludeIsFatal: bool = ...,
+                 unknownSectionIsFatal: bool = ...) -> None: ...
+
+    def getSection(self, s: str) -> Section: ...
+    def handleCommand(self, lineno: int, args: List[str]) -> Union[BaseData, KickstartCommand]: ...
+    def registerSection(self, obj: Section) -> None: ...
+    def readKickstartFromString(self, s: str, reset: bool = ...) -> None: ...
+    def readKickstart(self, f: str, reset: bool = ...) -> None: ...
+    def setupSections(self) -> None: ...

--- a/pykickstart/sections.pyi
+++ b/pykickstart/sections.pyi
@@ -1,0 +1,53 @@
+# Type stubs of pykickstart.sections
+#
+# David Shea <dshea@redhat.com>
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc. 
+#
+
+from typing import Any, Dict, List, Union
+
+from pykickstart.base import BaseHandler
+
+class Section(object):
+    # class attributes
+    allLines = ...      # type: bool
+    sectionOpen = ...   # type: str
+
+    # instance attributes
+    handler = ...       # type: BaseHandler
+    version = ...       # type: int
+
+    # class type
+    dataObj = ...       # type: type
+
+    def __init__(self, handler: BaseHandler, **kwargs: Any) -> None: ...
+    def handleLine(self, line: str) -> None: ...
+    def handleHeader(self, lineno: int, args: List[str]) -> None: ...
+
+    @property
+    def seen(self) -> bool: ...
+
+# These don't change anything from their parent types
+class NullSection(Section): ...
+class ScriptSection(Section): ...
+class PreScriptSection(ScriptSection): ...
+class PreInstallScriptSection(ScriptSection): ...
+class PostScriptSection(ScriptSection): ...
+class OnErrorScriptSection(ScriptSection): ...
+class TracebackScriptSection(OnErrorScriptSection): ...
+class PackageSection(Section): ...

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -105,7 +105,7 @@ versionMap = {
         "RHEL7": RHEL7
 }
 
-def stringToVersion(s): # type: (str) -> int
+def stringToVersion(s):
     """Convert string into one of the provided version constants.  Raises
        KickstartVersionError if string does not match anything.
     """
@@ -138,7 +138,7 @@ def stringToVersion(s): # type: (str) -> int
     # If nothing else worked, we're out of options.
     raise KickstartVersionError(_("Unsupported version specified: %s") % s)
 
-def versionToString(version, skipDevel=False):  # type: (int, bool) -> str
+def versionToString(version, skipDevel=False):
     """Convert version into a string representation of the version number.
        This is the reverse operation of stringToVersion.  Raises
        KickstartVersionError if version does not match anything.
@@ -154,7 +154,7 @@ def versionToString(version, skipDevel=False):  # type: (int, bool) -> str
 
     raise KickstartVersionError(_("Unsupported version specified: %s") % version)
 
-def versionFromFile(f): # type: (str) -> int
+def versionFromFile(f):
     """Given a file or URL, look for a line starting with #version= and
        return the version number.  If no version is found, return DEVEL.
     """
@@ -172,7 +172,7 @@ def versionFromFile(f): # type: (str) -> int
 
     return v
 
-def returnClassForVersion(version=DEVEL):   # type: (Union[int, str]) -> Callable[[], BaseHandler]
+def returnClassForVersion(version=DEVEL):
     """Return the class of the syntax handler for version.  version can be
        either a string or the matching constant.  Raises KickstartVersionError
        if version does not match anything.
@@ -188,8 +188,7 @@ def returnClassForVersion(version=DEVEL):   # type: (Union[int, str]) -> Callabl
 
     try:
         import pykickstart.handlers
-        # mypy does not understand module.__path__, skip
-        sys.path.extend(pykickstart.handlers.__path__)  # type: ignore
+        sys.path.extend(pykickstart.handlers.__path__)
         loaded = importlib.import_module(module)
 
         for (k, v) in list(loaded.__dict__.items()):
@@ -198,7 +197,7 @@ def returnClassForVersion(version=DEVEL):   # type: (Union[int, str]) -> Callabl
     except:
         raise KickstartVersionError(_("Unsupported version specified: %s") % version)
 
-def makeVersion(version=DEVEL): # type: (int) -> BaseHandler
+def makeVersion(version=DEVEL):
     """Return a new instance of the syntax handler for version.  version can be
        either a string or the matching constant.  This function is useful for
        standalone programs which just need to handle a specific version of

--- a/pykickstart/version.pyi
+++ b/pykickstart/version.pyi
@@ -1,0 +1,67 @@
+# type stubs for pykickstart.version
+#
+# David Shea <dshea@redhat.com>
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+
+from typing import Dict, Callable, Union
+
+from pykickstart.base import BaseHandler
+
+# Symbolic names for internal version numbers.
+RHEL3 = ...     # type: int
+FC3 = ...       # type: int
+RHEL4 = ...     # type: int
+FC4 = ...       # type: int
+FC5 = ...       # type: int
+FC6 = ...       # type: int
+RHEL5 = ...     # type: int
+F7  = ...       # type: int
+F8 = ...        # type: int
+F9 = ...        # type: int
+F10 = ...       # type: int
+F11 = ...       # type: int
+F12 = ...       # type: int
+F13 = ...       # type: int
+RHEL6 = ...     # type: int
+F14 = ...       # type: int
+F15 = ...       # type: int
+F16 = ...       # type: int
+F17 = ...       # type: int
+F18 = ...       # type: int
+F19 = ...       # type: int
+F20 = ...       # type: int
+F21 = ...       # type: int
+RHEL7 = ...     # type: int
+F22 = ...       # type: int
+F23 = ...       # type: int
+F24 = ...       # type: int
+F25 = ...       # type: int
+
+DEVEL = F25     # type: int
+
+versionMap = ...    # type: Dict[str, int]
+
+def stringToVersion(s: str) -> int: ...
+def versionToString(version: int, skipDevel: bool) -> str: ...
+def versionFromFile(f: str) -> int: ...
+
+# The return type is the class type of a BaseHandler
+def returnClassForVersion(version: Union[int, str]) -> Callable[[], BaseHandler]: ...
+
+def makeVersion(version: int) -> BaseHandler: ...

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(cmdclass={"install_scripts": install_scripts},
       url='http://fedoraproject.org/wiki/pykickstart',
       scripts=['tools/ksvalidator.py', 'tools/ksflatten.py', 'tools/ksverdiff.py', 'tools/ksshell.py'],
       packages=['pykickstart', 'pykickstart.commands', 'pykickstart.handlers'],
+      package_data={'': ['*.pyi']},
       data_files=[('share/man/man1', ['docs/ksvalidator.1', 'docs/ksflatten.1', 'docs/ksverdiff.1',
                                       'docs/ksshell.1'])])


### PR DESCRIPTION
mypy's --use-python-path option has been removed, since the results were
often misleading. Move the existing type comments into .pyi stub files,
which are installed to /usr/lib/python*/site-packages, and run the type
checks based on those.

The test for this is probably going to fail since I haven't actually built this new mypy yet.