### PR TITLE
[rhel7-branch] Support timezone command usage without timezone specification

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -1971,6 +1971,15 @@ Starting with Fedora 18 the ``timezone`` command has two new options:
     For example:
     ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
 
+Starting with RHEL 7.3 the timezone specification for the ``timezone`` command is optional, eq.:
+
+``timezone [--utc] [--nontp] [--ntpservers=<server1>,<server2>,...,<serverN>] [<timezone>]``
+
+This makes it possible to use options for the ``timezone`` command without setting a timezone, for example:
+
+``timezone --utc``
+
+But not that at leas one option and/or one timezone specififcation needs to be provided. Using just ``timezone`` in a kickstart is incorrect.
 
 updates
 -------

--- a/pykickstart/handlers/rhel7.py
+++ b/pykickstart/handlers/rhel7.py
@@ -80,7 +80,7 @@ class RHEL7Handler(BaseHandler):
         "sshkey": commands.sshkey.F22_SshKey,
         "sshpw": commands.sshpw.RHEL7_SshPw,
         "text": commands.displaymode.FC3_DisplayMode,
-        "timezone": commands.timezone.F18_Timezone,
+        "timezone": commands.timezone.RHEL7_Timezone,
         "unsupported_hardware": commands.unsupported_hardware.RHEL6_UnsupportedHardware,
         "updates": commands.updates.F7_Updates,
         "upgrade": commands.upgrade.F20_Upgrade,

--- a/tests/commands/timezone.py
+++ b/tests/commands/timezone.py
@@ -78,5 +78,21 @@ class F18_TestCase(FC6_TestCase):
                                 "ntp.cesnet.cz, tik.nic.cz",
                                 KickstartValueError)
 
+class RHEL7_TestCase(F18_TestCase):
+    def runTest(self):
+        # since RHEL7 command version the timezone command can be used
+        # without a timezone specification
+        self.assert_parse("timezone --utc")
+        self.assert_parse("timezone --isUtc")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz")
+        # unknown argument
+        self.assert_parse_error("timezone --blah")
+        # more than two timezone specs
+        self.assert_parse_error("timezone foo bar", exception=KickstartValueError)
+        self.assert_parse_error("timezone --utc foo bar", exception=KickstartValueError)
+        # just "timezone" without any arguments is also wrong as it really dosn't make sense
+        self.assert_parse_error("timezone")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Make it possible to use the timezone command without a timezone
specification.

This way the timezone command can be used with the --utc flag
to set hardware clock time format while still requiring the user
to select a timezone manually in the Anaconda UI.

Related: rhbz#1312135