### PR TITLE
Enable Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "3.5"
+
+install:
+  - pip install --upgrade pip setuptools
+  - pip install coverage mypy-lang nose ordered-set polib pylint requests six
+  - pip install https://github.com/rhinstaller/pocketlint/zipball/master
+
+script:
+  - make ci
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# pylint: disable=import-error,no-name-in-module
+# See https://github.com/PyCQA/pylint/issues/73#issuecomment-163171888
 from distutils.core import setup
 from distutils.command.install_scripts import install_scripts as _install_scripts
 from distutils.file_util import move_file

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/tools/ksflatten.py
+++ b/tools/ksflatten.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Simple script to take a kickstart config, read it in, parse any %includes,
 # etc to write out a flattened config that is stand-alone

--- a/tools/ksshell.py
+++ b/tools/ksshell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Chris Lumens <clumens@redhat.com>
 #

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Chris Lumens <clumens@redhat.com>
 #

--- a/tools/ksverdiff.py
+++ b/tools/ksverdiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Chris Lumens <clumens@redhat.com>
 #

--- a/translation-canary/tests/pylint/runpylint.py
+++ b/translation-canary/tests/pylint/runpylint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 from pocketlint import PocketLintConfig, PocketLinter


### PR DESCRIPTION
The only drawback I'm currently seeing is that multiprocessing and coverage don't play well in Travis. I frequently get some JSON errors or timeouts, see https://travis-ci.org/atodorov/pykickstart/builds/141046781.

However I've seen the same thing locally and I also think there's something wrong with the coverage generation from nose. The tools tests for example execute a subprocess with "coverage run ..." instead of relying on nose. I'll take a look at this in another PR. Maybe we'll want to disable multiprocessing for now, what do you think ?

