### PR TITLE
Test how command and data classes are defined

### DIFF
--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -431,4 +431,5 @@ class F21_AutoPart(F20_AutoPart):
 
         return retval
 
-RHEL7_AutoPart = F21_AutoPart
+class RHEL7_AutoPart(F21_AutoPart):
+    pass

--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -445,4 +445,6 @@ class F21_Bootloader(F19_Bootloader):
                         version=F21, help="")
         return op
 
-RHEL7_Bootloader = F21_Bootloader
+class RHEL7_Bootloader(F21_Bootloader):
+    pass
+

--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -93,7 +93,8 @@ class F23_BTRFSData(F17_BTRFSData):
 
         return retval
 
-RHEL7_BTRFSData = F23_BTRFSData
+class RHEL7_BTRFSData(F23_BTRFSData):
+    pass
 
 class F17_BTRFS(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -264,4 +265,5 @@ class F23_BTRFS(F17_BTRFS):
 
         return data
 
-RHEL7_BTRFS = F23_BTRFS
+class RHEL7_BTRFS(F23_BTRFS):
+    pass

--- a/pykickstart/commands/driverdisk.py
+++ b/pykickstart/commands/driverdisk.py
@@ -85,7 +85,8 @@ class F12_DriverDiskData(FC4_DriverDiskData):
         FC4_DriverDiskData.__init__(self, *args, **kwargs)
         self.deleteRemovedAttrs()
 
-F14_DriverDiskData = F12_DriverDiskData
+class F14_DriverDiskData(F12_DriverDiskData):
+    pass
 
 class FC3_DriverDisk(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/ignoredisk.py
+++ b/pykickstart/commands/ignoredisk.py
@@ -139,4 +139,6 @@ class RHEL6_IgnoreDisk(F8_IgnoreDisk):
                         screen.""")
         return op
 
-F14_IgnoreDisk = RHEL6_IgnoreDisk
+class F14_IgnoreDisk(RHEL6_IgnoreDisk):
+    pass
+

--- a/pykickstart/commands/iscsi.py
+++ b/pykickstart/commands/iscsi.py
@@ -90,7 +90,8 @@ class RHEL6_IscsiData(F10_IscsiData):
 
         return retval
 
-F17_IscsiData = RHEL6_IscsiData
+class F17_IscsiData(RHEL6_IscsiData):
+    pass
 
 class FC6_Iscsi(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -188,4 +189,6 @@ class RHEL6_Iscsi(F10_Iscsi):
                         """)
         return op
 # todo: how do we mark that --iface is available since F17, while RHEL6 is based on F12 ?
-F17_Iscsi = RHEL6_Iscsi
+
+class F17_Iscsi(RHEL6_Iscsi):
+    pass

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -210,7 +210,8 @@ class RHEL6_LogVolData(F12_LogVolData):
 
         return retval
 
-F14_LogVolData = F12_LogVolData
+class F14_LogVolData(F12_LogVolData):
+    pass
 
 class F15_LogVolData(F14_LogVolData):
     removedKeywords = F14_LogVolData.removedKeywords

--- a/pykickstart/commands/method.py
+++ b/pykickstart/commands/method.py
@@ -76,15 +76,20 @@ class FC3_Method(KickstartCommand):
 
 # These are all just for compat.  Calling into the appropriate version-specific
 # method command will deal with making sure the right options are used.
-FC6_Method = FC3_Method
+class FC6_Method(FC3_Method):
+    pass
 
-F13_Method = FC6_Method
+class F13_Method(FC6_Method):
+    pass
 
-F14_Method = F13_Method
+class F14_Method(F13_Method):
+    pass
 
-RHEL6_Method = F14_Method
+class RHEL6_Method(F14_Method):
+    pass
 
-F18_Method = F14_Method
+class F18_Method(F14_Method):
+    pass
 
 class F19_Method(FC3_Method):
     removedKeywords = FC3_Method.removedKeywords

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -85,4 +85,5 @@ class F21_OSTreeSetup(KickstartCommand):
 
         return self
 
-RHEL7_OSTreeSetup = F21_OSTreeSetup
+class RHEL7_OSTreeSetup(F21_OSTreeSetup):
+    pass

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -207,7 +207,8 @@ class RHEL6_PartData(F12_PartData):
 
         return retval
 
-F14_PartData = F12_PartData
+class F14_PartData(F12_PartData):
+    pass
 
 class F17_PartData(F14_PartData):
     removedKeywords = F14_PartData.removedKeywords
@@ -261,7 +262,8 @@ class F23_PartData(F18_PartData):
 
         return retval
 
-RHEL7_PartData = F23_PartData
+class RHEL7_PartData(F23_PartData):
+    pass
 
 class FC3_Partition(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -649,4 +651,5 @@ class F23_Partition(F20_Partition):
 
         return retval
 
-RHEL7_Partition = F23_Partition
+class RHEL7_Partition(F23_Partition):
+    pass

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -132,14 +132,15 @@ class RHEL5_RaidData(FC5_RaidData):
 
         return retval
 
-F7_RaidData = FC5_RaidData
+class F7_RaidData(FC5_RaidData):
+    pass
 
-class F9_RaidData(FC5_RaidData):
-    removedKeywords = FC5_RaidData.removedKeywords + ["bytesPerInode"]
-    removedAttrs = FC5_RaidData.removedAttrs + ["bytesPerInode"]
+class F9_RaidData(F7_RaidData):
+    removedKeywords = F7_RaidData.removedKeywords + ["bytesPerInode"]
+    removedAttrs = F7_RaidData.removedAttrs + ["bytesPerInode"]
 
     def __init__(self, *args, **kwargs):
-        FC5_RaidData.__init__(self, *args, **kwargs)
+        F7_RaidData.__init__(self, *args, **kwargs)
         self.deleteRemovedAttrs()
 
         self.fsprofile = kwargs.get("fsprofile", "")
@@ -147,7 +148,7 @@ class F9_RaidData(FC5_RaidData):
         self.passphrase = kwargs.get("passphrase", "")
 
     def _getArgsAsStr(self):
-        retval = FC5_RaidData._getArgsAsStr(self)
+        retval = F7_RaidData._getArgsAsStr(self)
 
         if self.fsprofile != "":
             retval += " --fsprofile=\"%s\"" % self.fsprofile
@@ -180,7 +181,8 @@ class F12_RaidData(F9_RaidData):
                 retval += " --backuppassphrase"
         return retval
 
-F13_RaidData = F12_RaidData
+class F13_RaidData(F12_RaidData):
+    pass
 
 class RHEL6_RaidData(F13_RaidData):
     removedKeywords = F13_RaidData.removedKeywords
@@ -199,7 +201,8 @@ class RHEL6_RaidData(F13_RaidData):
 
         return retval
 
-F14_RaidData = F13_RaidData
+class F14_RaidData(F13_RaidData):
+    pass
 
 class F15_RaidData(F14_RaidData):
     removedKeywords = F14_RaidData.removedKeywords
@@ -268,7 +271,8 @@ class F25_RaidData(F23_RaidData):
 
         return retval
 
-RHEL7_RaidData = F23_RaidData
+class RHEL7_RaidData(F23_RaidData):
+    pass
 
 class FC3_Raid(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -687,7 +691,8 @@ class F23_Raid(F20_Raid):
 
         return retval
 
-RHEL7_Raid = F23_Raid
+class RHEL7_Raid(F23_Raid):
+    pass
 
 class F25_Raid(F23_Raid):
     removedKeywords = F23_Raid.removedKeywords

--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -130,27 +130,30 @@ class F14_RepoData(F13_RepoData):
 
         return retval
 
-RHEL6_RepoData = F14_RepoData
+class RHEL6_RepoData(F14_RepoData):
+    pass
 
-F15_RepoData = F14_RepoData
+class F15_RepoData(F14_RepoData):
+    pass
 
-class F21_RepoData(F14_RepoData):
-    removedKeywords = F14_RepoData.removedKeywords
-    removedAttrs = F14_RepoData.removedAttrs
+class F21_RepoData(F15_RepoData):
+    removedKeywords = F15_RepoData.removedKeywords
+    removedAttrs = F15_RepoData.removedAttrs
 
     def __init__(self, *args, **kwargs):
-        F14_RepoData.__init__(self, *args, **kwargs)
+        F15_RepoData.__init__(self, *args, **kwargs)
         self.install = kwargs.get("install", False)
 
     def _getArgsAsStr(self):
-        retval = F14_RepoData._getArgsAsStr(self)
+        retval = F15_RepoData._getArgsAsStr(self)
 
         if self.install:
             retval += " --install"
 
         return retval
 
-RHEL7_RepoData = F21_RepoData
+class RHEL7_RepoData(F21_RepoData):
+    pass
 
 class FC6_Repo(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -336,7 +339,8 @@ class F14_Repo(F13_Repo):
                         """)
         return op
 
-RHEL6_Repo = F14_Repo
+class RHEL6_Repo(F14_Repo):
+    pass
 
 class F15_Repo(F14_Repo):
     removedKeywords = F14_Repo.removedKeywords
@@ -369,4 +373,5 @@ class F21_Repo(F15_Repo):
                         can be used after reboot.""")
         return op
 
-RHEL7_Repo = F21_Repo
+class RHEL7_Repo(F21_Repo):
+    pass

--- a/pykickstart/commands/reqpart.py
+++ b/pykickstart/commands/reqpart.py
@@ -86,4 +86,5 @@ class F23_ReqPart(KickstartCommand):
         self.reqpart = True
         return self
 
-RHEL7_ReqPart = F23_ReqPart
+class RHEL7_ReqPart(F23_ReqPart):
+    pass

--- a/pykickstart/commands/url.py
+++ b/pykickstart/commands/url.py
@@ -133,7 +133,8 @@ class F14_Url(F13_Url):
                         domain name.""")
         return op
 
-RHEL6_Url = F14_Url
+class RHEL6_Url(F14_Url):
+    pass
 
 class F18_Url(F14_Url):
     removedKeywords = F14_Url.removedKeywords

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -89,7 +89,8 @@ class F21_VolGroupData(FC16_VolGroupData):
         FC16_VolGroupData.__init__(self, *args, **kwargs)
         self.pesize = kwargs.get("pesize", 0)
 
-RHEL7_VolGroupData = F21_VolGroupData
+class RHEL7_VolGroupData(F21_VolGroupData):
+    pass
 
 class FC3_VolGroup(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -224,4 +225,5 @@ class F21_VolGroup(FC16_VolGroup):
                         Set the size of the physical extents in KiB.""")
         return op
 
-RHEL7_VolGroup = F21_VolGroup
+class RHEL7_VolGroup(F21_VolGroup):
+    pass

--- a/pykickstart/commands/zfcp.py
+++ b/pykickstart/commands/zfcp.py
@@ -79,7 +79,8 @@ class F12_ZFCPData(FC3_ZFCPData):
         return self.devnum == y.devnum and self.wwpn == y.wwpn and \
                self.fcplun == y.fcplun
 
-F14_ZFCPData = F12_ZFCPData
+class F14_ZFCPData(F12_ZFCPData):
+    pass
 
 class FC3_ZFCP(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import unittest
+import importlib
+from pykickstart.base import KickstartCommand, BaseData
+
+class ClassDefinitionTestCase(unittest.TestCase):
+    """
+        Search for command and data classes defined like so:
+
+        RHEL7_AutoPart = F21_AutoPart.
+
+        This kind of definitions makes it possible for other
+        tests to omit possible errors and we don't like to have
+        them. Either we use the existing class name if we haven't
+        redefined anything or provide a boilerplate definition:
+
+        class RHEL7_Autopart(F21_Autopart):
+            pass
+    """
+    def runTest(self):
+        errors = 0
+        commands_dir = os.path.join(os.path.dirname(__file__), "..", "..", "pykickstart", "commands")
+        commands_dir = os.path.abspath(commands_dir)
+
+        self.assertTrue(os.path.exists(commands_dir))
+        if commands_dir not in sys.path:
+            sys.path.append(commands_dir)
+
+        for dirpath, _dirnames, paths in os.walk(commands_dir):
+            for path in paths:
+                if path == '__init__.py' or not path.endswith('.py'):
+                    continue
+
+                # load the module defining all possible command implementations
+                command_module = importlib.import_module(path.replace(".py", ""))
+                module_commands = [] # a list of already checked commands
+
+                for impl_name, impl_class in command_module.__dict__.items():
+                    # skip everything which isn't a class
+                    if type(impl_class) is not type:
+                        continue
+
+                    # skip everything which doesn't inherit
+                    # from KickstartCommand or BaseData
+                    if not (issubclass(impl_class, KickstartCommand) or issubclass(impl_class, BaseData)):
+                        continue
+
+                    # skip base classes as well
+                    if impl_class.__name__ in ['KickstartCommand', 'DeprecatedCommand']:
+                        continue
+
+                    if impl_class not in module_commands and \
+                        impl_class.__name__ == impl_name:
+                        module_commands.append(impl_class)
+                    else:
+                        errors += 1
+                        message = "ERROR: In `commands/%s` %s = %s" % (path, impl_name, impl_class.__name__)
+                        print(message)
+
+
+        # assert for errors presence
+        self.assertEqual(0, errors)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is related to my previous comment at https://github.com/rhinstaller/pykickstart/pull/91#discussion-diff-69723629. Let's try to avoid the case where the definition looks like

	RHEL7_AutoPart = F21_AutoPart

b/c this can interfere with the commandMap handler test and allow the introduction of unwanted bugs. NOTE: these classes don't really do anything. we can either remove them and update the handler maps or properly inherit them from whatever is on the right hand side so that the handlers commandMap test has a better chance of detecting possible errors. The current list of offences is

```
ERROR: In `commands/autopart.py` RHEL7_AutoPart = F21_AutoPart

ERROR: In `commands/volgroup.py` RHEL7_VolGroup = F21_VolGroup

ERROR: In `commands/method.py` F14_Method = FC3_Method

ERROR: In `commands/method.py` F13_Method = FC3_Method

ERROR: In `commands/method.py` F18_Method = FC3_Method

ERROR: In `commands/method.py` FC6_Method = FC3_Method

ERROR: In `commands/method.py` RHEL6_Method = FC3_Method

ERROR: In `commands/ostreesetup.py` RHEL7_OSTreeSetup = F21_OSTreeSetup

ERROR: In `commands/partition.py` RHEL7_Partition = F23_Partition

ERROR: In `commands/raid.py` RHEL7_Raid = F23_Raid

ERROR: In `commands/repo.py` RHEL7_Repo = F21_Repo

ERROR: In `commands/repo.py` RHEL6_Repo = F14_Repo

ERROR: In `commands/reqpart.py` RHEL7_ReqPart = F23_ReqPart

ERROR: In `commands/url.py` RHEL6_Url = F14_Url

ERROR: In `commands/btrfs.py` RHEL7_BTRFS = F23_BTRFS

ERROR: In `commands/iscsi.py` F17_Iscsi = RHEL6_Iscsi

ERROR: In `commands/bootloader.py` RHEL7_Bootloader = F21_Bootloader

ERROR: In `commands/ignoredisk.py` F14_IgnoreDisk = RHEL6_IgnoreDisk
```

I'll update the code and clean those up tomorrow if you have no objections. 

CC @clumens, @bcl, @vpodzime 