### PR TITLE
Master version of the timezone-without-arguments patch

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -2002,6 +2002,15 @@ Starting with Fedora 18 the ``timezone`` command has two new options:
     For example:
     ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
 
+Starting with Fedora 25 and RHEL 7.3 the timezone specification for the ``timezone`` command is optional, eq.:
+
+``timezone [--utc] [--nontp] [--ntpservers=<server1>,<server2>,...,<serverN>] [<timezone>]``
+
+This makes it possible to use options for the ``timezone`` command without setting a timezone, for example:
+
+``timezone --utc``
+
+But not that at leas one option and/or one timezone specififcation needs to be provided. Using just ``timezone`` in a kickstart is incorrect.
 
 updates
 -------

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -69,6 +69,8 @@ class FC3_Timezone(KickstartCommand):
                         Timezone name, e.g. Europe/Sofia.""")
         return op
 
+    # Caution: This method is overridden in the RHEL7_Timezone & F25_Timezone classes
+    # by a new implementation not calling this method.
     def parse(self, args):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
         self.set_to_self(ns)
@@ -157,6 +159,8 @@ class F18_Timezone(FC6_Timezone):
                         """)
         return op
 
+    # Caution: The parse() method is overridden in the RHEL7_Timezone & F25_Timezone classes
+    # by a new implementation not calling this method.
     def parse(self, args):
         FC6_Timezone.parse(self, args)
 
@@ -174,8 +178,184 @@ class F23_Timezone(F18_Timezone):
         F18_Timezone.__init__(self, *args, **kwargs)
         self.ntpservers = kwargs.get("ntpservers", list())
 
+    # Caution: This method is overridden in the RHEL7_Timezone & F25_Timezone classes
+    # by a new implementation not calling this method.
     def parse(self, args):
         FC6_Timezone.parse(self, args)
+
+        if self.ntpservers and self.nontp:
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            raise KickstartParseError(msg)
+
+        return self
+
+# About the RHEL7_Timezone & F25_Timezone command classes
+# =======================================================
+#
+# The F18_Timezone command class used in RHEL <=7.2 the F23_Timezone
+# command class used in Fedora <=24 the always required a timezone
+# specification to be provided.
+#
+# On the other hand the timezone command has also some commands that don't
+# really need a timezone to be specified to work, like "--utc/--isutc".
+#
+# So if you for example wanted to set the hwclock to the UTC mode but still
+# wanted the user to set a timezone manually in the UI (by not providing a
+# timezone specification), you were out of luck - a timezone parsing error
+# would be raised.
+#
+# To fix this we need to remove the requirement on always providing one
+# argument to the timezone command. As the requirement is present
+# quite deep in the class hierarchy (in the original FC3_Timezone class)
+# we reimplement the parse() method in the RHEL7_Timezone and F25_Timezone
+# classes and avoid calling the ancestors parse(), as it otherwise done in all
+# other command child classes.
+
+class RHEL7_Timezone(F18_Timezone):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F18_Timezone.__init__(self, writePriority, *args, **kwargs)
+        self.op = self._getParser()
+
+    def _getParser(self):
+        op = KSOptionParser(prog="timezone", description="""
+                            This required command sets the system time zone to
+                            which may be any of the time zones listed by
+                            timeconfig.""", version=FC3)
+        op.add_argument("timezone", metavar="<timezone>", nargs="?",
+                        version=FC3, help="""
+                        Timezone name, e.g. Europe/Sofia.
+                        This is optional but at least one of the options needs
+                        to be used if no timezone is specified.
+                        """)
+        op.add_argument("--utc", "--isUtc", dest="isUtc", action="store_true",
+                        default=False, version=FC6, help="""
+                        If present, the system assumes the hardware clock is set
+                        to UTC (Greenwich Mean) time.
+
+                       *To get the list of supported timezones, you can either
+                        run this script:
+                        http://vpodzime.fedorapeople.org/timezones_list.py or
+                        look at this list:
+                        http://vpodzime.fedorapeople.org/timezones_list.txt*
+                        """)
+        op.add_argument("--nontp", action="store_true", default=False,
+                        version=F18, help="""
+                        Disable automatic starting of NTP service.
+
+                        ``--nontp`` and ``--ntpservers`` are mutually exclusive.
+                        """)
+        op.add_argument("--ntpservers", dest="ntpservers", type=commaSplit,
+                        metavar="<server1>,<server2>,...,<serverN>",
+                        version=F18, help="""
+                        Specify a list of NTP servers to be used (comma-separated
+                        list with no spaces). The chrony package is automatically
+                        installed when this option is used. If you don't want the
+                        package to be automatically installed then use ``-chrony``
+                        in package selection. For example::
+
+                        ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
+                        """)
+        return op
+
+    def parse(self, args):
+        ns = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(ns)
+
+        # just "timezone" without any arguments and timezone specification doesn't really make sense,
+        # so throw an error when we see it (it might even be an indication of an incorrect machine generated kickstart)
+        if not args:
+            error_message = _("At least one option and/or an argument are expected for the  %s command") % "timezone"
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        # To be able to support the timezone command being used without
+        # a timezone specification:
+        # - we don't call the parse() method of the ancestors
+        # -> due to the FC3 parse() method that would be eventually called,
+        #    which throws an exception if no timezone specification is provided
+        # - we implement the relevant functionality of the ancestor methods here
+
+        if ns.timezone:
+            if len(ns.timezone) == 1:
+                self.timezone = ns.timezone[0]
+            elif len(ns.timezone) > 1:
+                error_message = _("One or zero arguments are expected for the %s command") % "timezone"
+                raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        if self.ntpservers and self.nontp:
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            raise KickstartParseError(msg)
+
+        return self
+
+class F25_Timezone(F23_Timezone):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F23_Timezone.__init__(self, writePriority, *args, **kwargs)
+        self.op = self._getParser()
+
+    def _getParser(self):
+        op = KSOptionParser(prog="timezone", description="""
+                            This required command sets the system time zone to
+                            which may be any of the time zones listed by
+                            timeconfig.""", version=FC3)
+        op.add_argument("timezone", metavar="<timezone>", nargs="?",
+                        version=FC3, help="""
+                        Timezone name, e.g. Europe/Sofia.
+                        This is optional but at least one of the options needs
+                        to be used if no timezone is specified.
+                        """)
+        op.add_argument("--utc", "--isUtc", dest="isUtc", action="store_true",
+                        default=False, version=FC6, help="""
+                        If present, the system assumes the hardware clock is set
+                        to UTC (Greenwich Mean) time.
+
+                       *To get the list of supported timezones, you can either
+                        run this script:
+                        http://vpodzime.fedorapeople.org/timezones_list.py or
+                        look at this list:
+                        http://vpodzime.fedorapeople.org/timezones_list.txt*
+                        """)
+        op.add_argument("--nontp", action="store_true", default=False,
+                        version=F18, help="""
+                        Disable automatic starting of NTP service.
+
+                        ``--nontp`` and ``--ntpservers`` are mutually exclusive.
+                        """)
+        op.add_argument("--ntpservers", dest="ntpservers", type=commaSplit,
+                        metavar="<server1>,<server2>,...,<serverN>",
+                        version=F18, help="""
+                        Specify a list of NTP servers to be used (comma-separated
+                        list with no spaces). The chrony package is automatically
+                        installed when this option is used. If you don't want the
+                        package to be automatically installed then use ``-chrony``
+                        in package selection. For example::
+
+                        ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
+                        """)
+        return op
+
+    def parse(self, args):
+        ns = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(ns)
+
+        # just "timezone" without any arguments and timezone specification doesn't really make sense,
+        # so throw an error when we see it (it might even be an indication of an incorrect machine generated kickstart)
+        if not args:
+            error_message = _("At least one option and/or an argument are expected for the  %s command") % "timezone"
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        # To be able to support the timezone command being used without
+        # a timezone specification:
+        # - we don't call the parse() method of the ancestors
+        # -> due to the FC3 parse() method that would be eventually called,
+        #    which throws an exception if no timezone specification is provided
+        # - we implement the relevant functionality of the ancestor methods here
+
+        if ns.timezone:
+            if len(ns.timezone) == 1:
+                self.timezone = ns.timezone[0]
+            elif len(ns.timezone) > 1:
+                error_message = _("One or zero arguments are expected for the %s command") % "timezone"
+                raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
 
         if self.ntpservers and self.nontp:
             msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -15,7 +15,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 from pykickstart.version import FC3, FC6, F18
 from pykickstart.base import KickstartCommand
@@ -44,7 +44,7 @@ class FC3_Timezone(KickstartCommand):
             else:
                 utc = ""
 
-            retval += "# System timezone\ntimezone %s %s\n" %(utc, self.timezone)
+            retval += "# System timezone\ntimezone %s %s\n" % (utc, self.timezone)
 
         return retval
 
@@ -95,7 +95,7 @@ class FC6_Timezone(FC3_Timezone):
             else:
                 utc = ""
 
-            retval += "# System timezone\ntimezone %s %s\n" %(utc, self.timezone)
+            retval += "# System timezone\ntimezone %s %s\n" % (utc, self.timezone)
 
         return retval
 
@@ -164,8 +164,7 @@ class F18_Timezone(FC6_Timezone):
         self.ntpservers = list(set(self.ntpservers))
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and "\
-                                    "--ntpservers are mutually exclusive"))
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
             raise KickstartParseError(msg)
 
         return self
@@ -179,8 +178,7 @@ class F23_Timezone(F18_Timezone):
         FC6_Timezone.parse(self, args)
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and "\
-                                    "--ntpservers are mutually exclusive"))
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
             raise KickstartParseError(msg)
 
         return self

--- a/pykickstart/handlers/f25.py
+++ b/pykickstart/handlers/f25.py
@@ -80,7 +80,7 @@ class F25Handler(BaseHandler):
         "sshpw": commands.sshpw.F24_SshPw,
         "sshkey": commands.sshkey.F22_SshKey,
         "text": commands.displaymode.FC3_DisplayMode,
-        "timezone": commands.timezone.F23_Timezone,
+        "timezone": commands.timezone.F25_Timezone,
         "updates": commands.updates.F7_Updates,
         "upgrade": commands.upgrade.F20_Upgrade,
         "url": commands.url.F18_Url,

--- a/pykickstart/handlers/rhel7.py
+++ b/pykickstart/handlers/rhel7.py
@@ -79,7 +79,7 @@ class RHEL7Handler(BaseHandler):
         "skipx": commands.skipx.FC3_SkipX,
         "sshpw": commands.sshpw.F13_SshPw,
         "text": commands.displaymode.FC3_DisplayMode,
-        "timezone": commands.timezone.F18_Timezone,
+        "timezone": commands.timezone.RHEL7_Timezone,
         "unsupported_hardware": commands.unsupported_hardware.RHEL6_UnsupportedHardware,
         "updates": commands.updates.F7_Updates,
         "upgrade": commands.upgrade.F20_Upgrade,

--- a/tests/commands/timezone.py
+++ b/tests/commands/timezone.py
@@ -20,6 +20,8 @@
 import unittest
 from tests.baseclass import CommandTest
 
+from pykickstart.errors import KickstartParseError
+
 class FC3_TestCase(CommandTest):
     command = "timezone"
 
@@ -88,6 +90,38 @@ class F23_TestCase(F18_TestCase):
                           "timezone Europe/Prague --isUtc --ntpservers=ntp.cesnet.cz,0.fedora.pool.ntp.org," +
                           "0.fedora.pool.ntp.org,0.fedora.pool.ntp.org,0.fedora.pool.ntp.org\n")
         self.assert_parse("timezone --utc Europe/Sofia --ntpservers=,0.fedora.pool.ntp.org,")
+
+class RHEL7_TestCase(F18_TestCase):
+    def runTest(self):
+        # since RHEL7 command version the timezone command can be used
+        # without a timezone specification
+        self.assert_parse("timezone --utc")
+        self.assert_parse("timezone --isUtc")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz")
+        # unknown argument
+        self.assert_parse_error("timezone --blah")
+        # more than two timezone specs
+        self.assert_parse_error("timezone foo bar", exception=KickstartParseError)
+        self.assert_parse_error("timezone --utc foo bar", exception=KickstartParseError)
+        # just "timezone" without any arguments is also wrong as it really dosn't make sense
+        self.assert_parse_error("timezone")
+
+class F25_TestCase(F23_TestCase):
+    def runTest(self):
+        # since RHEL7 command version the timezone command can be used
+        # without a timezone specification
+        self.assert_parse("timezone --utc")
+        self.assert_parse("timezone --isUtc")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz")
+        # unknown argument
+        self.assert_parse_error("timezone --blah")
+        # more than two timezone specs
+        self.assert_parse_error("timezone foo bar", exception=KickstartParseError)
+        self.assert_parse_error("timezone --utc foo bar", exception=KickstartParseError)
+        # just "timezone" without any arguments is also wrong as it really dosn't make sense
+        self.assert_parse_error("timezone")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a separate RHEL7 & F25 version of the modified timezone command & the corresponding tests, as suggested in:

https://github.com/rhinstaller/pykickstart/pull/87#issuecomment-225897780