### PR TITLE
Pykickstart 2 version of the timezone-without-arguments patch

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -1961,6 +1961,15 @@ Starting with Fedora 18 the ``timezone`` command has two new options:
     For example:
     ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
 
+Starting with Fedora 25 and RHEL 7.3 the timezone specification for the ``timezone`` command is optional, eq.:
+
+``timezone [--utc] [--nontp] [--ntpservers=<server1>,<server2>,...,<serverN>] [<timezone>]``
+
+This makes it possible to use options for the ``timezone`` command without setting a timezone, for example:
+
+``timezone --utc``
+
+But not that at leas one option and/or one timezone specififcation needs to be provided. Using just ``timezone`` in a kickstart is incorrect.
 
 updates
 -------

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -15,7 +15,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartValueError, formatErrorMsg
@@ -43,7 +43,7 @@ class FC3_Timezone(KickstartCommand):
             else:
                 utc = ""
 
-            retval += "# System timezone\ntimezone %s %s\n" %(utc, self.timezone)
+            retval += "# System timezone\ntimezone %s %s\n" % (utc, self.timezone)
 
         return retval
 
@@ -75,7 +75,7 @@ class FC6_Timezone(FC3_Timezone):
             else:
                 utc = ""
 
-            retval += "# System timezone\ntimezone %s %s\n" %(utc, self.timezone)
+            retval += "# System timezone\ntimezone %s %s\n" % (utc, self.timezone)
 
         return retval
 
@@ -132,8 +132,7 @@ class F18_Timezone(FC6_Timezone):
         FC6_Timezone.parse(self, args)
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and "\
-                                    "--ntpservers are mutually exclusive"))
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
             raise KickstartParseError(msg)
 
         return self
@@ -148,7 +147,6 @@ class F23_Timezone(F18_Timezone):
             for server in value.split(","):
                 if server:
                     parser.values.ensure_value(option.dest, list()).append(server)
-
 
         op = FC6_Timezone._getParser(self)
         op.add_option("--nontp", dest="nontp", action="store_true", default=False)

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -52,6 +52,8 @@ class FC3_Timezone(KickstartCommand):
         op.add_option("--utc", dest="isUtc", action="store_true", default=False)
         return op
 
+    # Caution: This method is overridden in the RHEL7_Timezone & F25_Timezone classes
+    # by a new implementation not calling this method.
     def parse(self, args):
         (opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
         self.set_to_self(self.op, opts)
@@ -128,6 +130,8 @@ class F18_Timezone(FC6_Timezone):
 
         return op
 
+    # Caution: The parse() method is overridden in the RHEL7_Timezone & F25_Timezone classes
+    # by a new implementation not calling this method.
     def parse(self, args):
         FC6_Timezone.parse(self, args)
 
@@ -142,6 +146,8 @@ class F23_Timezone(F18_Timezone):
         F18_Timezone.__init__(self, *args, **kwargs)
         self.ntpservers = kwargs.get("ntpservers", list())
 
+    # Caution: The parse() method is overridden in the RHEL7_Timezone & F25_Timezone classes
+    # by a new implementation not calling this method.
     def _getParser(self):
         def servers_cb(option, opt_str, value, parser):
             for server in value.split(","):
@@ -154,3 +160,92 @@ class F23_Timezone(F18_Timezone):
                       callback=servers_cb, nargs=1, type="string")
 
         return op
+
+# About the RHEL7_Timezone & F25_Timezone command classes
+# =======================================================
+#
+# The F18_Timezone command class used in RHEL <=7.2 and Fedora <=24 the
+# timezone command always required a ti,ezone specification to be provided.
+#
+# On the other hand the timezone command has also some commands that don't
+# really need a timezone to be specicifed to work, like "--utc/--isutc".
+#
+# So if you for example wanted to set the hwclock to the UTC mode but still
+# wanted the user to set a timezone manually in the UI (by not providing a
+# timezone specification), you were out of luck - a timezone parsing error
+# would be raised.
+#
+# To fix this we need to remove the requirement on always providing one
+# argument to the timezone command. As the requirement is present
+# quite deep in the class hierarchy (in the original FC3_Timezone class)
+# we reimplement the parse() method in the RHEL7_Timezone and F25_Timezone
+# classes and avoid calling the ancestors parse(), as it otherwise done in all
+# other command child classes.
+
+class RHEL7_Timezone(F18_Timezone):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F18_Timezone.__init__(self, writePriority, *args, **kwargs)
+
+    def parse(self, args):
+        (opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
+        self._setToSelf(self.op, opts)
+
+        # just "timezone" without any arguments and timezone specification doesn't really make sense,
+        # so throw an error when we see it (it might even be an indication of an incorrect machine generated kickstart)
+        if not args:
+            error_message = _("At least one option and/or an argument are expected for the  %s command") % "timezone"
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        # To be able to support the timezone command being used without
+        # a timezone specification:
+        # - we don't call the parse() method of the ancestors
+        # -> due to the FC3 parse() method that would be eventually called,
+        #    which throws an exception if no timezone specification is provided
+        # - we implement the relevant functionality of the ancestor methods here
+
+        if len(extra) > 1:
+            error_message = _("One or zero arguments are expected for the %s command") % "timezone"
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        if len(extra) > 0:
+            self.timezone = extra[0]
+
+        if self.ntpservers and self.nontp:
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            raise KickstartParseError(msg)
+
+        return self
+
+class F25_Timezone(F18_Timezone):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F18_Timezone.__init__(self, writePriority, *args, **kwargs)
+
+    def parse(self, args):
+        (opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
+        self._setToSelf(self.op, opts)
+
+        # just "timezone" without any arguments and timezone specification doesn't really make sense,
+        # so throw an error when we see it (it might even be an indication of an incorrect machine generated kickstart)
+        if not args:
+            error_message = _("At least one option and/or an argument are expected for the  %s command") % "timezone"
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        # To be able to support the timezone command being used without
+        # a timezone specification:
+        # - we don't call the parse() method of the ancestors
+        # -> due to the FC3 parse() method that would be eventually called,
+        #    which throws an exception if no timezone specification is provided
+        # - we implement the relevant functionality of the ancestor methods here
+
+        if len(extra) > 1:
+            error_message = _("One or zero arguments are expected for the %s command") % "timezone"
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message))
+
+        if len(extra) > 0:
+            self.timezone = extra[0]
+
+        if self.ntpservers and self.nontp:
+            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            raise KickstartParseError(msg)
+
+        return self

--- a/pykickstart/handlers/f25.py
+++ b/pykickstart/handlers/f25.py
@@ -80,7 +80,7 @@ class F25Handler(BaseHandler):
         "sshpw": commands.sshpw.F24_SshPw,
         "sshkey": commands.sshkey.F22_SshKey,
         "text": commands.displaymode.FC3_DisplayMode,
-        "timezone": commands.timezone.F23_Timezone,
+        "timezone": commands.timezone.F25_Timezone,
         "updates": commands.updates.F7_Updates,
         "upgrade": commands.upgrade.F20_Upgrade,
         "url": commands.url.F18_Url,

--- a/pykickstart/handlers/rhel7.py
+++ b/pykickstart/handlers/rhel7.py
@@ -79,7 +79,7 @@ class RHEL7Handler(BaseHandler):
         "skipx": commands.skipx.FC3_SkipX,
         "sshpw": commands.sshpw.F13_SshPw,
         "text": commands.displaymode.FC3_DisplayMode,
-        "timezone": commands.timezone.F18_Timezone,
+        "timezone": commands.timezone.RHEL7_Timezone,
         "unsupported_hardware": commands.unsupported_hardware.RHEL6_UnsupportedHardware,
         "updates": commands.updates.F7_Updates,
         "upgrade": commands.upgrade.F20_Upgrade,

--- a/tests/commands/timezone.py
+++ b/tests/commands/timezone.py
@@ -93,5 +93,37 @@ class F23_TestCase(F18_TestCase):
                           "0.fedora.pool.ntp.org,0.fedora.pool.ntp.org,0.fedora.pool.ntp.org\n")
         self.assert_parse("timezone --utc Europe/Sofia --ntpservers=,0.fedora.pool.ntp.org,")
 
+class RHEL7_TestCase(F18_TestCase):
+    def runTest(self):
+        # since RHEL7 command version the timezone command can be used
+        # without a timezone specification
+        self.assert_parse("timezone --utc")
+        self.assert_parse("timezone --isUtc")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz")
+        # unknown argument
+        self.assert_parse_error("timezone --blah")
+        # more than two timezone specs
+        self.assert_parse_error("timezone foo bar", exception=KickstartParseError)
+        self.assert_parse_error("timezone --utc foo bar", exception=KickstartParseError)
+        # just "timezone" without any arguments is also wrong as it really dosn't make sense
+        self.assert_parse_error("timezone")
+
+class F25_TestCase(F18_TestCase):
+    def runTest(self):
+        # since RHEL7 command version the timezone command can be used
+        # without a timezone specification
+        self.assert_parse("timezone --utc")
+        self.assert_parse("timezone --isUtc")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz")
+        # unknown argument
+        self.assert_parse_error("timezone --blah")
+        # more than two timezone specs
+        self.assert_parse_error("timezone foo bar", exception=KickstartParseError)
+        self.assert_parse_error("timezone --utc foo bar", exception=KickstartParseError)
+        # just "timezone" without any arguments is also wrong as it really dosn't make sense
+        self.assert_parse_error("timezone")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a separate RHEL7 & F25 version of the modified timezone command & the corresponding tests, as suggested in:

https://github.com/rhinstaller/pykickstart/pull/87#issuecomment-225897780