### PR TITLE
Py2 add noninteractive

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -593,6 +593,15 @@ graphical
 Perform the kickstart installation in graphical mode. This is the
 default.
 
+``graphical [--non-interactive]``
+
+``--non-interactive``
+
+    Perform the installation in a completely non-interactive mode.
+    This mode will kill the installation when user interaction will be
+    required. Behavior of this mode is similar to ``cmdline`` or
+    ``text --non-interactive`` modes but with graphics.
+
 
 halt
 ----
@@ -1973,6 +1982,13 @@ text
 
 Perform the kickstart installation in text mode. Kickstart installations
 are performed in graphical mode by default.
+
+``text [--non-interactive]``
+
+``--non-interactive``
+
+    If present, run the installation in completely non interactive text
+    mode. This mode behaves same as the ``cmdline`` mode.
 
 
 timezone

--- a/pykickstart/commands/displaymode.py
+++ b/pykickstart/commands/displaymode.py
@@ -15,10 +15,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 from pykickstart.base import KickstartCommand
-from pykickstart.constants import DISPLAY_MODE_CMDLINE, DISPLAY_MODE_GRAPHICAL, DISPLAY_MODE_TEXT
+from pykickstart.constants import DISPLAY_MODE_CMDLINE, DISPLAY_MODE_GRAPHICAL, \
+                                  DISPLAY_MODE_TEXT
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
@@ -53,10 +54,12 @@ class FC3_DisplayMode(KickstartCommand):
         return op
 
     def parse(self, args):
-        (_opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
+        (opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(self.op, opts)
 
         if len(extra) > 0:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s does not take any arguments") % self.currentCmd))
+            msg = _("Kickstart command %s does not take any arguments") % self.currentCmd
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg))
 
         if self.currentCmd == "cmdline":
             self.displayMode = DISPLAY_MODE_CMDLINE
@@ -64,5 +67,39 @@ class FC3_DisplayMode(KickstartCommand):
             self.displayMode = DISPLAY_MODE_GRAPHICAL
         elif self.currentCmd == "text":
             self.displayMode = DISPLAY_MODE_TEXT
+
+        return self
+
+class F26_DisplayMode(FC3_DisplayMode):
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+
+    def __init__(self, writePriority=0, *args, **kwargs):
+        FC3_DisplayMode.__init__(self, writePriority, args, kwargs)
+        self.op = self._getParser()
+        self.displayMode = kwargs.get("displayMode", None)
+        self.nonInteractive = kwargs.get("nonInteractive", False)
+
+    def __str__(self):
+        retval = super(F26_DisplayMode, self).__str__()
+
+        if self.nonInteractive:
+            retval = retval.rstrip()
+            retval += " --non-interactive\n"
+
+        return retval
+
+    def _getParser(self):
+        op = FC3_DisplayMode._getParser(self)
+        op.add_option("--non-interactive", action="store_true", default=False,
+                      dest="nonInteractive")
+        return op
+
+    def parse(self, args):
+        FC3_DisplayMode.parse(self, args)
+
+        if self.currentCmd == "cmdline" and self.nonInteractive:
+            msg = _("Kickstart command cmdline does not support --non-interactive parameter")
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg))
 
         return self

--- a/pykickstart/constants.py
+++ b/pykickstart/constants.py
@@ -15,7 +15,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 CLEARPART_TYPE_LINUX = 0
 CLEARPART_TYPE_ALL = 1

--- a/pykickstart/handlers/__init__.py
+++ b/pykickstart/handlers/__init__.py
@@ -19,5 +19,5 @@
 #
 from pykickstart.handlers import \
      fc3, fc4, fc5, fc6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, \
-     f18, f19, f20, f21, f22, f23, f24, f25, \
+     f18, f19, f20, f21, f22, f23, f24, f25, f26, \
      rhel3, rhel4, rhel5, rhel6, rhel7

--- a/pykickstart/handlers/f26.py
+++ b/pykickstart/handlers/f26.py
@@ -1,0 +1,114 @@
+#
+# Jiri Konecny <jkonecny@redhat.com>
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+__all__ = ["F26Handler"]
+
+from pykickstart import commands
+from pykickstart.base import BaseHandler
+from pykickstart.version import F26
+
+class F26Handler(BaseHandler):
+    version = F26
+
+    commandMap = {
+        "auth": commands.authconfig.FC3_Authconfig,
+        "authconfig": commands.authconfig.FC3_Authconfig,
+        "autopart": commands.autopart.F21_AutoPart,
+        "autostep": commands.autostep.FC3_AutoStep,
+        "bootloader": commands.bootloader.F21_Bootloader,
+        "btrfs": commands.btrfs.F23_BTRFS,
+        "cdrom": commands.cdrom.FC3_Cdrom,
+        "clearpart": commands.clearpart.F21_ClearPart,
+        "cmdline": commands.displaymode.F26_DisplayMode,
+        "device": commands.device.F8_Device,
+        "deviceprobe": commands.deviceprobe.FC3_DeviceProbe,
+        "dmraid": commands.dmraid.FC6_DmRaid,
+        "driverdisk": commands.driverdisk.F14_DriverDisk,
+        "eula": commands.eula.F20_Eula,
+        "fcoe": commands.fcoe.F13_Fcoe,
+        "firewall": commands.firewall.F20_Firewall,
+        "firstboot": commands.firstboot.FC3_Firstboot,
+        "graphical": commands.displaymode.F26_DisplayMode,
+        "group": commands.group.F12_Group,
+        "halt": commands.reboot.F23_Reboot,
+        "harddrive": commands.harddrive.FC3_HardDrive,
+        "ignoredisk": commands.ignoredisk.F14_IgnoreDisk,
+        "install": commands.upgrade.F11_Upgrade,
+        "iscsi": commands.iscsi.F17_Iscsi,
+        "iscsiname": commands.iscsiname.FC6_IscsiName,
+        "keyboard": commands.keyboard.F18_Keyboard,
+        "lang": commands.lang.F19_Lang,
+        "liveimg": commands.liveimg.F19_Liveimg,
+        "logging": commands.logging.FC6_Logging,
+        "logvol": commands.logvol.F23_LogVol,
+        "mediacheck": commands.mediacheck.FC4_MediaCheck,
+        "method": commands.method.F19_Method,
+        "multipath": commands.multipath.FC6_MultiPath,
+        "network": commands.network.F25_Network,
+        "nfs": commands.nfs.FC6_NFS,
+        "ostreesetup": commands.ostreesetup.F21_OSTreeSetup,
+        "part": commands.partition.F23_Partition,
+        "partition": commands.partition.F23_Partition,
+        "poweroff": commands.reboot.F23_Reboot,
+        "raid": commands.raid.F25_Raid,
+        "realm": commands.realm.F19_Realm,
+        "reboot": commands.reboot.F23_Reboot,
+        "repo": commands.repo.F21_Repo,
+        "reqpart": commands.reqpart.F23_ReqPart,
+        "rescue": commands.rescue.F10_Rescue,
+        "rootpw": commands.rootpw.F18_RootPw,
+        "selinux": commands.selinux.FC3_SELinux,
+        "services": commands.services.FC6_Services,
+        "shutdown": commands.reboot.F23_Reboot,
+        "skipx": commands.skipx.FC3_SkipX,
+        "sshpw": commands.sshpw.F24_SshPw,
+        "sshkey": commands.sshkey.F22_SshKey,
+        "text": commands.displaymode.F26_DisplayMode,
+        "timezone": commands.timezone.F25_Timezone,
+        "updates": commands.updates.F7_Updates,
+        "upgrade": commands.upgrade.F20_Upgrade,
+        "url": commands.url.F18_Url,
+        "user": commands.user.F19_User,
+        "vnc": commands.vnc.F9_Vnc,
+        "volgroup": commands.volgroup.F21_VolGroup,
+        "xconfig": commands.xconfig.F14_XConfig,
+        "zerombr": commands.zerombr.F9_ZeroMbr,
+        "zfcp": commands.zfcp.F14_ZFCP,
+    }
+
+    dataMap = {
+        "BTRFSData": commands.btrfs.F23_BTRFSData,
+        "DriverDiskData": commands.driverdisk.F14_DriverDiskData,
+        "DeviceData": commands.device.F8_DeviceData,
+        "DmRaidData": commands.dmraid.FC6_DmRaidData,
+        "FcoeData": commands.fcoe.F13_FcoeData,
+        "GroupData": commands.group.F12_GroupData,
+        "IscsiData": commands.iscsi.F17_IscsiData,
+        "LogVolData": commands.logvol.F23_LogVolData,
+        "MultiPathData": commands.multipath.FC6_MultiPathData,
+        "NetworkData": commands.network.F25_NetworkData,
+        "PartData": commands.partition.F23_PartData,
+        "RaidData": commands.raid.F25_RaidData,
+        "RepoData": commands.repo.F21_RepoData,
+        "SshPwData": commands.sshpw.F24_SshPwData,
+        "SshKeyData": commands.sshkey.F22_SshKeyData,
+        "UserData": commands.user.F19_UserData,
+        "VolGroupData": commands.volgroup.F21_VolGroupData,
+        "ZFCPData": commands.zfcp.F14_ZFCPData,
+    }

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -89,9 +89,10 @@ F22 = 20000
 F23 = 21000
 F24 = 22000
 F25 = 23000
+F26 = 24000
 
 # This always points at the latest version and is the default.
-DEVEL = F25
+DEVEL = F26
 
 # A one-to-one mapping from string representations to version numbers.
 versionMap = {
@@ -100,7 +101,7 @@ versionMap = {
         "F9": F9, "F10": F10, "F11": F11, "F12": F12, "F13": F13,
         "F14": F14, "F15": F15, "F16": F16, "F17": F17, "F18": F18,
         "F19": F19, "F20": F20, "F21": F21, "F22": F22, "F23": F23,
-        "F24": F24, "F25": F25,
+        "F24": F24, "F25": F25, "F26": F26,
         "RHEL3": RHEL3, "RHEL4": RHEL4, "RHEL5": RHEL5, "RHEL6": RHEL6,
         "RHEL7": RHEL7
 }

--- a/tests/commands/displaymode.py
+++ b/tests/commands/displaymode.py
@@ -14,7 +14,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 
 import unittest
@@ -52,6 +52,19 @@ class FC3_TestCase(CommandTest):
         cmd.currentCmd = None
         cmd.parse([])
 
+
+class F26_TestCase(FC3_TestCase):
+    def runTest(self):
+        #pass
+        self.assert_parse("text --non-interactive", "text --non-interactive\n")
+        self.assert_parse("graphical --non-interactive", "graphical --non-interactive\n")
+
+        #fail
+        self.assert_parse_error("cmdline --non-interactive", KickstartParseError)
+        self.assert_parse_error("text --non-interactive-test", KickstartParseError)
+        self.assert_parse_error("text --non-interactive --test", KickstartParseError)
+        self.assert_parse_error("graphical --non-interactive-test", KickstartParseError)
+        self.assert_parse_error("graphical --non-interactive --test", KickstartParseError)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/version.py
+++ b/tests/version.py
@@ -111,6 +111,9 @@ class StringToVersion_TestCase(CommandTest):
         # pass - F25
         self.assertEqual(stringToVersion("Fedora 25"), F25)
         self.assertEqual(stringToVersion("F25"), F25)
+        # pass - F26
+        self.assertEqual(stringToVersion("Fedora 26"), F26)
+        self.assertEqual(stringToVersion("F26"), F26)
 
         # pass - RHEL3
         self.assertEqual(stringToVersion("Red Hat Enterprise Linux 3"), RHEL3)
@@ -199,7 +202,8 @@ class VersionToString_TestCase(CommandTest):
         self.assertEqual(versionToString(F23, skipDevel=True), "F23")
         self.assertEqual(versionToString(F24, skipDevel=True), "F24")
         self.assertEqual(versionToString(F25, skipDevel=True), "F25")
-        self.assertEqual(versionToString(F25, skipDevel=False), "DEVEL")
+        self.assertEqual(versionToString(F26, skipDevel=True), "F26")
+        self.assertEqual(versionToString(F26, skipDevel=False), "DEVEL")
         # RHEL series
         self.assertEqual(versionToString(RHEL3), "RHEL3")
         self.assertEqual(versionToString(RHEL4), "RHEL4")


### PR DESCRIPTION
To prevent kickstart tests timeouts I need to add non-interactive mode which will kill installation instead of waiting on user interaction.

Anaconda patch will follow after the `anaconda.py` PR will be merged.