### PR TITLE
Print errors to stderr when errors aren't fatal

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -669,7 +669,7 @@ class KickstartParser(object):
             if self.errorsAreFatal:
                 raise
             else:
-                print(msg)
+                print(msg, file=sys.stderr)
 
     def _isBlankOrComment(self, line):
         return line.isspace() or line == "" or line.lstrip()[0] == '#'


### PR DESCRIPTION
When errors are printed to `stdout` instead of `stderr` then Dracut takes this Pykickstart errors as output from parse-kickstart script.