### PR TITLE
Print errors to stderr when errors aren't fatal

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -673,7 +673,7 @@ class KickstartParser(object):
             if self.errorsAreFatal:
                 raise
             else:
-                print(msg)
+                print(msg, file=sys.stderr)
 
     def _isBlankOrComment(self, line):
         return line.isspace() or line == "" or line.lstrip()[0] == '#'


### PR DESCRIPTION
When errors are printed to stdout instead of stderr then Dracut takes this Pykickstart errors as output from `parse-kickstart` script.

Cherry-pick of PR https://github.com/rhinstaller/pykickstart/pull/117 on master