### PR TITLE
Remove duplicated kwargs.get displayMode variable

### DIFF
--- a/pykickstart/commands/displaymode.py
+++ b/pykickstart/commands/displaymode.py
@@ -77,7 +77,6 @@ class F26_DisplayMode(FC3_DisplayMode):
     def __init__(self, writePriority=0, *args, **kwargs):
         FC3_DisplayMode.__init__(self, writePriority, args, kwargs)
         self.op = self._getParser()
-        self.displayMode = kwargs.get("displayMode", None)
         self.nonInteractive = kwargs.get("nonInteractive", False)
 
     def __str__(self):


### PR DESCRIPTION
This is already in `FC3_DisplayMode` class so there is no need to have this in `F26_DisplayMode` class.

Introduced in PR https://github.com/rhinstaller/pykickstart/pull/111 . As far as I understand this, it shouldn't be used twice in the same command.