### PR TITLE
Ignore errors from coverage tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ coverage:
 	@which $(COVERAGE) || (echo "*** Please install coverage (python3-coverage) ***"; exit 2)
 	@echo "*** Running unittests with coverage ***"
 	PYTHONPATH=. $(PYTHON) -m nose --with-coverage --cover-erase --cover-branches --cover-package=pykickstart --cover-package=tools $(NOSEARGS)
-	$(COVERAGE) combine
-	$(COVERAGE) report -m | tee coverage-report.log
+	-$(COVERAGE) combine
+	-$(COVERAGE) report -m | tee coverage-report.log
 	@which mypy || (echo "*** Please install mypy (python3-mypy) ***"; exit 2)
 	@echo "*** Running type checks ***"
 	PYTHONPATH=. mypy pykickstart


### PR DESCRIPTION
Now builds are failing because `coverage combine` doesn't work on Rawhide. It would be nice to find why this is happening but so or so this is not a reason for build to fail.