### PR TITLE
Add support for --chunksize option to RHEL7.

### DIFF
--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -265,7 +265,7 @@ class F25_RaidData(F23_RaidData):
 
         return retval
 
-RHEL7_RaidData = F23_RaidData
+RHEL7_RaidData = F25_RaidData
 
 class FC3_Raid(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -539,4 +539,4 @@ class F25_Raid(F23_Raid):
         op.add_option("--chunksize", type="int", dest="chunk_size")
         return op
 
-RHEL7_Raid = F23_Raid
+RHEL7_Raid = F25_Raid

--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -309,14 +309,14 @@ class F23_TestCase(F19_TestCase):
         self.assert_parse_error("raid / --device=md0 --level=1 --mkfsoptions=some,thing --fsprofile=PROFILE raid.01 raid.02",
                                 KickstartValueError)
 
-RHEL7_TestCase = F23_TestCase
-
 class F25_TestCase(F23_TestCase):
     def runTest(self):
         F23_TestCase.runTest(self)
 
         # pass
         self.assert_parse("raid / --device=md0 --level=1 --chunksize=512 raid.01 raid.02")
+
+RHEL7_TestCase = F25_TestCase
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Classes RHEL7_Raid and RHEL7_RaidData should use base classes
F25_Raid and F25_RaidData, that already support the --chunksize
option.