### PR TITLE
Add support for --chunksize option to RHEL7.

### DIFF
--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -274,7 +274,7 @@ class F25_RaidData(F23_RaidData):
 
         return retval
 
-class RHEL7_RaidData(F23_RaidData):
+class RHEL7_RaidData(F25_RaidData):
     pass
 
 class FC3_Raid(KickstartCommand):
@@ -690,9 +690,6 @@ class F23_Raid(F20_Raid):
 
         return retval
 
-class RHEL7_Raid(F23_Raid):
-    pass
-
 class F25_Raid(F23_Raid):
     removedKeywords = F23_Raid.removedKeywords
     removedAttrs = F23_Raid.removedAttrs
@@ -704,3 +701,6 @@ class F25_Raid(F23_Raid):
                         Specify the chunk size (in KiB) for this RAID array.
                         """)
         return op
+
+class RHEL7_Raid(F25_Raid):
+    pass

--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -364,9 +364,9 @@ class F25_TestCase(F23_TestCase):
         self.assert_parse("raid / --device=md0 --level=1 --chunksize=512 raid.01 raid.02",
                           "raid / --device=0 --level=RAID1 --chunksize=512 raid.01 raid.02\n")
 
-class RHEL7_TestCase(F23_TestCase):
+class RHEL7_TestCase(F25_TestCase):
     def runTest(self):
-        F23_TestCase.runTest(self)
+        F25_TestCase.runTest(self)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Classes RHEL7_Raid and RHEL7_RaidData should use base classes
F25_Raid and F25_RaidData, that already support the --chunksize
option.