### PR TITLE
Add --nohome option to autopart command to RHEL7.

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -227,6 +227,9 @@ large enough drives, this will also create a /home partition.
     scheme and a filesystem. eg. --fstype=ext4. Added in
     anaconda-21.46-1
 
+``--nohome``
+
+    Do not create a /home partition.
 
 autostep
 --------

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -381,4 +381,28 @@ class F21_AutoPart(F20_AutoPart):
 
         return retval
 
-RHEL7_AutoPart = F21_AutoPart
+class RHEL7_AutoPart(F21_AutoPart):
+    removedKeywords = F21_AutoPart.removedKeywords
+    removedAttrs = F21_AutoPart.removedAttrs
+
+    def __init__(self, writePriority=100, *args, **kwargs):
+        F21_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
+        self.nohome = kwargs.get("nohome", False)
+
+    def __str__(self):
+        retval = F21_AutoPart.__str__(self)
+        if not self.autopart:
+            return retval
+
+        if self.nohome:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --nohome"
+            retval += "\n"
+
+        return retval
+
+    def _getParser(self):
+        op = F21_AutoPart._getParser(self)
+        op.add_option("--nohome", dest="nohome", action="store_true", default=False)
+        return op

--- a/pykickstart/handlers/rhel7.py
+++ b/pykickstart/handlers/rhel7.py
@@ -29,7 +29,7 @@ class RHEL7Handler(BaseHandler):
     commandMap = {
         "auth": commands.authconfig.FC3_Authconfig,
         "authconfig": commands.authconfig.FC3_Authconfig,
-        "autopart": commands.autopart.F20_AutoPart,
+        "autopart": commands.autopart.RHEL7_AutoPart,
         "autostep": commands.autostep.FC3_AutoStep,
         "bootloader": commands.bootloader.RHEL7_Bootloader,
         "btrfs": commands.btrfs.RHEL7_BTRFS,

--- a/tests/commands/autopart.py
+++ b/tests/commands/autopart.py
@@ -169,7 +169,19 @@ class F21_TestCase(F20_TestCase):
         self.assert_parse_error("autopart --fstype=btrfs")
         self.assert_parse_error("autopart --type=btrfs --fstype=xfs")
 
-RHEL7_TestCase = F21_TestCase
+class RHEL7_TestCase(F21_TestCase):
+    def runTest(self):
+        F21_TestCase.runTest(self)
+
+        # pass
+        self.assert_parse("autopart --nohome",
+                          'autopart --nohome\n')
+
+        # fail
+        self.assert_parse_error("autopart --nohome=xxx")
+        self.assert_parse_error("autopart --nohome True", KickstartValueError)
+        self.assert_parse_error("autopart --nohome=1")
+        self.assert_parse_error("autopart --nohome 0", KickstartValueError)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A /home partition will not be created with --nohome option.

(cherry picked from commit b83b669)