### PR TITLE
Add --nohome, --noboot and --noswap options to autopart command.

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -231,6 +231,15 @@ large enough drives, this will also create a /home partition.
 
     Do not create a /home partition.
 
+``--noboot``
+
+    Do not create a /boot partition.
+
+``--noswap``
+
+    Do not create a swap partition.
+
+
 autostep
 --------
 

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -406,3 +406,45 @@ class RHEL7_AutoPart(F21_AutoPart):
         op = F21_AutoPart._getParser(self)
         op.add_option("--nohome", dest="nohome", action="store_true", default=False)
         return op
+
+class F26_AutoPart(F21_AutoPart):
+    removedKeywords = F21_AutoPart.removedKeywords
+    removedAttrs = F21_AutoPart.removedAttrs
+
+    def __init__(self, writePriority=100, *args, **kwargs):
+        F21_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
+        self.nohome = kwargs.get("nohome", False)
+        self.noboot = kwargs.get("noboot", False)
+        self.noswap = kwargs.get("noswap", False)
+
+    def __str__(self):
+        retval = F21_AutoPart.__str__(self)
+        if not self.autopart:
+            return retval
+
+        if self.nohome:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --nohome"
+            retval += "\n"
+
+        if self.noboot:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --noboot"
+            retval += "\n"
+
+        if self.noswap:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --noswap"
+            retval += "\n"
+
+        return retval
+
+    def _getParser(self):
+        op = F21_AutoPart._getParser(self)
+        op.add_option("--nohome", dest="nohome", action="store_true", default=False)
+        op.add_option("--noboot", dest="noboot", action="store_true", default=False)
+        op.add_option("--noswap", dest="noswap", action="store_true", default=False)
+        return op

--- a/pykickstart/handlers/f26.py
+++ b/pykickstart/handlers/f26.py
@@ -29,7 +29,7 @@ class F26Handler(BaseHandler):
     commandMap = {
         "auth": commands.authconfig.FC3_Authconfig,
         "authconfig": commands.authconfig.FC3_Authconfig,
-        "autopart": commands.autopart.F21_AutoPart,
+        "autopart": commands.autopart.F26_AutoPart,
         "autostep": commands.autostep.FC3_AutoStep,
         "bootloader": commands.bootloader.F21_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,

--- a/tests/commands/autopart.py
+++ b/tests/commands/autopart.py
@@ -183,5 +183,36 @@ class RHEL7_TestCase(F21_TestCase):
         self.assert_parse_error("autopart --nohome=1")
         self.assert_parse_error("autopart --nohome 0", KickstartValueError)
 
+class F26_TestCase(F21_TestCase):
+    def runTest(self):
+        F21_TestCase.runTest(self)
+
+        # pass
+        self.assert_parse("autopart --nohome",
+                          'autopart --nohome\n')
+        self.assert_parse("autopart --noboot",
+                          'autopart --noboot\n')
+        self.assert_parse("autopart --noswap",
+                          'autopart --noswap\n')
+        self.assert_parse("autopart --nohome --noboot --noswap",
+                          'autopart --nohome --noboot --noswap\n')
+
+        # fail
+        self.assert_parse_error("autopart --nohome=xxx")
+        self.assert_parse_error("autopart --nohome True", KickstartValueError)
+        self.assert_parse_error("autopart --nohome=1")
+        self.assert_parse_error("autopart --nohome 0", KickstartValueError)
+
+        self.assert_parse_error("autopart --noboot=xxx")
+        self.assert_parse_error("autopart --noboot True", KickstartValueError)
+        self.assert_parse_error("autopart --noboot=1")
+        self.assert_parse_error("autopart --noboot 0", KickstartValueError)
+
+        self.assert_parse_error("autopart --noswap=xxx")
+        self.assert_parse_error("autopart --noswap True", KickstartValueError)
+        self.assert_parse_error("autopart --noswap=1")
+        self.assert_parse_error("autopart --noswap 0", KickstartValueError)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added new options to autopart command in Fedora 26:

A /home partition will not be created with --nohome option.
A /boot partition will not be created with --noboot option.
A swap partition will not be created with --noswap option.