### PR TITLE
Add --nohome, --noboot and --noswap options to autopart command.

### DIFF
--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.base import KickstartCommand
 from pykickstart.version import versionToLongString, RHEL6, RHEL7
-from pykickstart.version import FC3, F9, F12, F16, F17, F18, F20, F21
+from pykickstart.version import FC3, F9, F12, F16, F17, F18, F20, F21, F26
 from pykickstart.constants import AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP, AUTOPART_TYPE_PLAIN
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
@@ -480,3 +480,51 @@ class RHEL7_AutoPart(F21_AutoPart):
             raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg))
 
         return retval
+
+class F26_AutoPart(F23_AutoPart):
+    removedKeywords = F23_AutoPart.removedKeywords
+    removedAttrs = F23_AutoPart.removedAttrs
+
+    def __init__(self, writePriority=100, *args, **kwargs):
+        F23_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
+        self.nohome = kwargs.get("nohome", False)
+        self.noboot = kwargs.get("noboot", False)
+        self.noswap = kwargs.get("noswap", False)
+
+    def __str__(self):
+        retval = F23_AutoPart.__str__(self)
+        if not self.autopart:
+            return retval
+
+        if self.nohome:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --nohome"
+            retval += "\n"
+
+        if self.noboot:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --noboot"
+            retval += "\n"
+
+        if self.noswap:
+            # remove any trailing newline
+            retval = retval.strip()
+            retval += " --noswap"
+            retval += "\n"
+
+        return retval
+
+    def _getParser(self):
+        op = F23_AutoPart._getParser(self)
+        op.add_argument("--nohome", action="store_true", default=False,
+                        version=F26, help="""
+                        Do not create a /home partition.""")
+        op.add_argument("--noboot", action="store_true", default=False,
+                        version=F26, help="""
+                        Do not create a /boot partition.""")
+        op.add_argument("--noswap", action="store_true", default=False,
+                        version=F26, help="""
+                        Do not create a swap partition.""")
+        return op

--- a/pykickstart/handlers/f26.py
+++ b/pykickstart/handlers/f26.py
@@ -29,7 +29,7 @@ class F26Handler(BaseHandler):
     commandMap = {
         "auth": commands.authconfig.FC3_Authconfig,
         "authconfig": commands.authconfig.FC3_Authconfig,
-        "autopart": commands.autopart.F23_AutoPart,
+        "autopart": commands.autopart.F26_AutoPart,
         "autostep": commands.autostep.FC3_AutoStep,
         "bootloader": commands.bootloader.F21_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,

--- a/tests/commands/autopart.py
+++ b/tests/commands/autopart.py
@@ -272,5 +272,40 @@ class RHEL7_Conflict_TestCase(CommandSequenceTest):
 reqpart
 autopart""")
 
+
+class F26_TestCase(F23_TestCase):
+    def runTest(self):
+        F23_TestCase.runTest(self)
+
+        # pass
+        self.assert_parse("autopart --nohome",
+                          'autopart --nohome\n')
+        self.assert_parse("autopart --noboot",
+                          'autopart --noboot\n')
+        self.assert_parse("autopart --noswap",
+                          'autopart --noswap\n')
+        self.assert_parse("autopart --nohome --noboot --noswap",
+                          'autopart --nohome --noboot --noswap\n')
+
+        # fail
+        self.assert_parse_error("autopart --nohome=xxx")
+        self.assert_parse_error("autopart --nohome True")
+        self.assert_parse_error("autopart --nohome=1")
+        self.assert_parse_error("autopart --nohome 0")
+
+        self.assert_parse_error("autopart --noboot=xxx")
+        self.assert_parse_error("autopart --noboot True")
+        self.assert_parse_error("autopart --noboot=1")
+        self.assert_parse_error("autopart --noboot 0")
+
+        self.assert_parse_error("autopart --noswap=xxx")
+        self.assert_parse_error("autopart --noswap True")
+        self.assert_parse_error("autopart --noswap=1")
+        self.assert_parse_error("autopart --noswap 0")
+
+class F26_Conflict_TestCase(F23_Conflict_TestCase):
+    def runTest(self):
+        F23_Conflict_TestCase.runTest(self)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added new options to autopart command in Fedora 26:

A /home partition will not be created with --nohome option.
A /boot partition will not be created with --noboot option.
A swap partition will not be created with --noswap option.

(cherry picked from a808dd9)