### PR TITLE
Mention that repo name must not contain spaces

### DIFF
--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -196,11 +196,13 @@ class FC6_Repo(KickstartCommand):
                             cause a conflicting repo error.""",
                             version=FC6)
         op.add_argument("--name", required=True, version=FC6, help="""
-                        The repo id. This option is required. If a repo has a
-                        name that conflicts with a previously added one, the
-                        new repo will be ignored. Because anaconda has a
-                        populated list of repos when it starts, this means that
-                        users cannot create new repos that override these names.
+                        The repo id. This option is required. The RepoId must 
+                        not contain spaces (do not confuse with the optional name
+                        used by yum). If a repo has a name that conflicts with a 
+                        previously added one, the new repo will be ignored. 
+                        Because anaconda has a populated list of repos when it 
+                        starts, this means that users cannot create new repos 
+                        that override these names.
                         Please check /etc/anaconda.repos.d from the operating
                         system you wish to install to see what names are not
                         available.""")


### PR DESCRIPTION
The Repo --name kickstart option is actually the Yum RepoId and not the Yum name. 
This has been the source of lot of confusion: https://bugzilla.redhat.com/show_bug.cgi?id=885151 and https://bugs.centos.org/view.php?id=7609