### PR TITLE
network: add network --bindto option

### DIFF
--- a/pykickstart/constants.py
+++ b/pykickstart/constants.py
@@ -15,7 +15,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 CLEARPART_TYPE_LINUX = 0
 CLEARPART_TYPE_ALL = 1
@@ -66,3 +66,5 @@ BOOTPROTO_IBFT = "ibft"
 GROUP_REQUIRED = 0
 GROUP_DEFAULT = 1
 GROUP_ALL = 2
+
+BIND_TO_MAC = "mac"

--- a/tests/commands/network.py
+++ b/tests/commands/network.py
@@ -22,6 +22,7 @@ from tests.baseclass import *
 
 from pykickstart.errors import *
 from pykickstart.commands.network import *
+from pykickstart.constants import BIND_TO_MAC
 
 class F20_TestCase(CommandTest):
     command = "network"
@@ -163,6 +164,21 @@ class RHEL7_TestCase(F20_TestCase):
         self.assertEquals(network_data.activate, False)
         network_data = self.assert_parse("network --device eth0 --no-activate --activate")
         self.assertEquals(network_data.activate, True)
+
+        # binding the configuration to mac
+        network_data = self.assert_parse("network --device eth0 --bindto mac")
+        self.assertEquals(network_data.bindto, BIND_TO_MAC)
+        network_data = self.assert_parse("network --device eth0")
+        self.assertIsNone(network_data.bindto)
+        # not allowed for vlan device type
+        vlan_cmd = "network --device ens3 --vlanid 222 --bootproto dhcp"
+        self.assert_parse(vlan_cmd)
+        self.assert_parse_error(vlan_cmd + " --bindto mac", KickstartValueError)
+        # but allowed for vlan over bond defined by single command, binds bond slaves
+        vlan_over_bond_cmd = "network --device bond0 --bootproto static --ip 10.34.39.222 --netmask 255.255.255.0 --gateway 10.34.39.254 --bondslaves=ens4,ens5 --bondopts=mode=active-backup,miimon-100,primary=ens4 --activate --vlanid=222 --activate --onboot=no"
+        self.assert_parse(vlan_over_bond_cmd)
+        self.assert_parse(vlan_over_bond_cmd + " --bindto mac")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By default ifcfgs/connections are bound to device name in anaconda (DEVICE).
This option allows to bind to mac address (HWADDR).

Related: rhbz#1328576