### PR TITLE
Backport spec file changes from downstream

### DIFF
--- a/pykickstart.spec
+++ b/pykickstart.spec
@@ -1,6 +1,6 @@
 Name:      pykickstart
 Version:   3.7
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   GPLv2 and MIT
 Group:     System Environment/Libraries
 Summary:   Python utilities for manipulating kickstart files.
@@ -37,13 +37,15 @@ can be found in the packages python-kickstart and python3-kickstart
 respectively.
 
 # Python 2 library
-%package -n python-kickstart
+%package -n python2-kickstart
+%{?python_provide:%python_provide python2-kickstart}
+%{?python_provide:%python_provide python2-pykickstart}
 Summary:  Python 2 library for manipulating kickstart files.
 Requires: python-six
 Requires: python-requests
 Requires: python-ordered-set
 
-%description -n python-kickstart
+%description -n python2-kickstart
 Python 2 library for manipulating kickstart files.  The binaries are found in
 the pykickstart package.
 
@@ -96,7 +98,7 @@ popd
 %{_bindir}/ksshell
 %{_mandir}/man1/*
 
-%files -n python-kickstart
+%files -n python2-kickstart
 %defattr(-,root,root,-)
 %doc docs/2to3
 %doc docs/programmers-guide
@@ -119,6 +121,11 @@ popd
 %{python3_sitelib}/pykickstart/locale/
 
 %changelog
+* Fri Sep 15 2017 Jiri Konecny <jkonecny@redhat.com> - 3.7-2
+- Backport of the Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl> from downstream spec
+  Python 2 binary package renamed to python2-pykickstart
+  See https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3
+
 * Tue Jul 18 2017 Chris Lumens <clumens@redhat.com> - 3.7-1
 - Add a Makefile target for uploading to pypi (#162). (clumens)
 - Remove some old, unneeded stuff from the Makefile. (clumens)


### PR DESCRIPTION
Changes to rename `python-pykickstart` to `python2-pykickstart` by Zbigniew Jędrzejewski-Szmek.