### PR TITLE
Call the _ method from i18n.py

### DIFF
--- a/pykickstart/commands/reqpart.py
+++ b/pykickstart/commands/reqpart.py
@@ -21,9 +21,7 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
-# typeshed is missing the stub for ldgettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart.i18n import _
 
 class F23_ReqPart(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords

--- a/pykickstart/commands/snapshot.py
+++ b/pykickstart/commands/snapshot.py
@@ -23,8 +23,7 @@ from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 from pykickstart.constants import SNAPSHOT_WHEN_POST_INSTALL, SNAPSHOT_WHEN_PRE_INSTALL
 
-import gettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart.i18n import _
 
 class RHEL7_SnapshotData(BaseData):
     removedKeywords = BaseData.removedKeywords


### PR DESCRIPTION
`Gettext` can sometimes return bytes which needs to be converted and this is handled in the `i18n.py` source file.

This should fix broken Rawhide builds.