### PR TITLE
Call the _ method from i18n.py

### DIFF
--- a/pykickstart/commands/reqpart.py
+++ b/pykickstart/commands/reqpart.py
@@ -22,9 +22,7 @@ from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
-import gettext
-# typeshed is missing the stub for ldgettext
-_ = lambda x: gettext.ldgettext("pykickstart", x)
+from pykickstart.i18n import _
 
 class F23_ReqPart(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords


### PR DESCRIPTION
`Gettext` can sometimes return bytes which needs to be converted and this is handled in the `i18n.py` source file.

This should fix broken Rawhide builds.