### PR TITLE
Pylint fixes

### DIFF
--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -107,7 +107,7 @@ class KSOptionParser(OptionParser):
 
         return OptionParser.add_option(self, *args, **kwargs)
 
-    def parse_args(self, *args, **kwargs):
+    def parse_args(self, *args, **kwargs):  # pylint: disable=arguments-differ
         if "lineno" in kwargs:
             self.lineno = kwargs.pop("lineno")
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -149,7 +149,7 @@ class CommandTest(unittest.TestCase):
         args = shlex.split(inputStr, comments=True)
         cmd = args[0]
 
-        parser = self.handler().commands[cmd]
+        parser = self.handler().commands[cmd]  # pylint: disable=not-callable
         parser.currentLine = inputStr
         parser.currentCmd = args[0]
         parser.seen = True

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -2,9 +2,16 @@
 
 import sys
 
-from pocketlint import PocketLintConfig, PocketLinter
+from pocketlint import FalsePositive, PocketLintConfig, PocketLinter
 
 class PykickstartLintConfig(PocketLintConfig):
+    def __init__(self):
+        PocketLintConfig.__init__(self)
+
+        self.falsePositives = [
+            FalsePositive(r"^E1102.*: .*_TestCase.runTest: self.handler is not callable$"),
+        ]
+
     @property
     def ignoreNames(self):
         return {"translation-canary"}


### PR DESCRIPTION
* Ignore a false positive 'self.handler is not callable' in tests.
* Ignore that parameters differ from overridden 'parse_args' method.