### PR TITLE
Fix which Autopart class checks for the 'mount' command

### DIFF
--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -174,8 +174,6 @@ class RHEL6_AutoPart(F12_AutoPart):
             conflicting_command = "logvol"
         elif hasattr(self.handler, "reqpart") and self.handler.reqpart.seen:
             conflicting_command = "reqpart"
-        elif hasattr(self.handler, "mount") and self.handler.mount.seen:
-            conflicting_command = "mount"
 
         if conflicting_command:
             # allow for translation of the error message
@@ -334,6 +332,8 @@ class F20_AutoPart(F18_AutoPart):
             conflicting_command = "logvol"
         elif hasattr(self.handler, "reqpart") and self.handler.reqpart.seen:
             conflicting_command = "reqpart"
+        elif hasattr(self.handler, "mount") and self.handler.mount.seen:
+            conflicting_command = "mount"
 
         if conflicting_command:
             # allow for translation of the error message


### PR DESCRIPTION
It should be the F20_Autopart version from which new versions of
the class used in Fedora 20+ and RHEL 7 inherit, not the archaic
RHEL6 version of the class which can never meet the 'mount'
command.