### PR TITLE
Add clearpart --cdl option

### DIFF
--- a/pykickstart/commands/clearpart.py
+++ b/pykickstart/commands/clearpart.py
@@ -17,7 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, F17, F21
+from pykickstart.version import FC3, F17, F21, F28
 from pykickstart.base import KickstartCommand
 from pykickstart.constants import CLEARPART_TYPE_ALL, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_LIST, CLEARPART_TYPE_NONE
 from pykickstart.options import KSOptionParser, commaSplit
@@ -150,3 +150,25 @@ class F21_ClearPart(F17_ClearPart):
                         supported for the platform will be accepted. eg. msdos
                         and gpt for x86_64 but not dasd.""")
         return op
+
+class F28_ClearPart(F21_ClearPart):
+    def __init__(self, *args, **kwargs):
+        super(F28_ClearPart, self).__init__(*args, **kwargs)
+        self.cdl = kwargs.get("cdl", False)
+
+    def __str__(self):
+        s = super(F28_ClearPart, self).__str__()
+        if s and self.cdl:
+            s = s.rstrip()
+            s += " --cdl\n"
+        return s
+
+    def _getParser(self):
+        op = super(F28_ClearPart, self)._getParser()
+        op.add_argument("--cdl", dest="cdl", default=False, version=F28,
+                        action="store_true", help="""
+                        Reformat any LDL DASDs to CDL format.""")
+        return op
+
+class RHEL7_ClearPart(F28_ClearPart):
+    pass

--- a/pykickstart/commands/mount.py
+++ b/pykickstart/commands/mount.py
@@ -19,7 +19,7 @@
 #
 
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartValueError, KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 from pykickstart.version import F27
 
@@ -174,7 +174,7 @@ class F27_Mount(KickstartCommand):
             mapping = {"command": "mount", "options": extra}
             raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping))
 
-        md = self.dataClass()
+        md = self.dataClass()  # pylint: disable=not-callable
         self.set_to_obj(ns, md)
         md.lineno = self.lineno
         md.device = ns.device[0]

--- a/pykickstart/handlers/f28.py
+++ b/pykickstart/handlers/f28.py
@@ -34,7 +34,7 @@ class F28Handler(BaseHandler):
         "bootloader": commands.bootloader.F21_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,
         "cdrom": commands.cdrom.FC3_Cdrom,
-        "clearpart": commands.clearpart.F21_ClearPart,
+        "clearpart": commands.clearpart.F28_ClearPart,
         "cmdline": commands.displaymode.F26_DisplayMode,
         "device": commands.device.F24_Device,
         "deviceprobe": commands.deviceprobe.FC3_DeviceProbe,

--- a/pykickstart/handlers/f28.py
+++ b/pykickstart/handlers/f28.py
@@ -1,0 +1,118 @@
+#
+# Vendula Poncova <vponcova@redhat.com>
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+__all__ = ["F28Handler"]
+
+from pykickstart import commands
+from pykickstart.base import BaseHandler
+from pykickstart.version import F28
+
+class F28Handler(BaseHandler):
+    version = F28
+
+    commandMap = {
+        "auth": commands.authconfig.FC3_Authconfig,
+        "authconfig": commands.authconfig.FC3_Authconfig,
+        "autopart": commands.autopart.F26_AutoPart,
+        "autostep": commands.autostep.FC3_AutoStep,
+        "bootloader": commands.bootloader.F21_Bootloader,
+        "btrfs": commands.btrfs.F23_BTRFS,
+        "cdrom": commands.cdrom.FC3_Cdrom,
+        "clearpart": commands.clearpart.F21_ClearPart,
+        "cmdline": commands.displaymode.F26_DisplayMode,
+        "device": commands.device.F24_Device,
+        "deviceprobe": commands.deviceprobe.FC3_DeviceProbe,
+        "dmraid": commands.dmraid.F24_DmRaid,
+        "driverdisk": commands.driverdisk.F14_DriverDisk,
+        "eula": commands.eula.F20_Eula,
+        "fcoe": commands.fcoe.F13_Fcoe,
+        "firewall": commands.firewall.F20_Firewall,
+        "firstboot": commands.firstboot.FC3_Firstboot,
+        "graphical": commands.displaymode.F26_DisplayMode,
+        "group": commands.group.F12_Group,
+        "halt": commands.reboot.F23_Reboot,
+        "harddrive": commands.harddrive.FC3_HardDrive,
+        "ignoredisk": commands.ignoredisk.F14_IgnoreDisk,
+        "install": commands.install.F20_Install,
+        "iscsi": commands.iscsi.F17_Iscsi,
+        "iscsiname": commands.iscsiname.FC6_IscsiName,
+        "keyboard": commands.keyboard.F18_Keyboard,
+        "lang": commands.lang.F19_Lang,
+        "liveimg": commands.liveimg.F19_Liveimg,
+        "logging": commands.logging.FC6_Logging,
+        "logvol": commands.logvol.F23_LogVol,
+        "mediacheck": commands.mediacheck.FC4_MediaCheck,
+        "method": commands.method.F19_Method,
+        "mount": commands.mount.F27_Mount,
+        "multipath": commands.multipath.F24_MultiPath,
+        "network": commands.network.F27_Network,
+        "nfs": commands.nfs.FC6_NFS,
+        "ostreesetup": commands.ostreesetup.F21_OSTreeSetup,
+        "part": commands.partition.F23_Partition,
+        "partition": commands.partition.F23_Partition,
+        "poweroff": commands.reboot.F23_Reboot,
+        "raid": commands.raid.F25_Raid,
+        "realm": commands.realm.F19_Realm,
+        "reboot": commands.reboot.F23_Reboot,
+        "repo": commands.repo.F27_Repo,
+        "reqpart": commands.reqpart.F23_ReqPart,
+        "rescue": commands.rescue.F10_Rescue,
+        "rootpw": commands.rootpw.F18_RootPw,
+        "selinux": commands.selinux.FC3_SELinux,
+        "services": commands.services.FC6_Services,
+        "shutdown": commands.reboot.F23_Reboot,
+        "skipx": commands.skipx.FC3_SkipX,
+        "snapshot": commands.snapshot.F26_Snapshot,
+        "sshpw": commands.sshpw.F24_SshPw,
+        "sshkey": commands.sshkey.F22_SshKey,
+        "text": commands.displaymode.F26_DisplayMode,
+        "timezone": commands.timezone.F25_Timezone,
+        "updates": commands.updates.F7_Updates,
+        "upgrade": commands.upgrade.F20_Upgrade,
+        "url": commands.url.F27_Url,
+        "user": commands.user.F24_User,
+        "vnc": commands.vnc.F9_Vnc,
+        "volgroup": commands.volgroup.F21_VolGroup,
+        "xconfig": commands.xconfig.F14_XConfig,
+        "zerombr": commands.zerombr.F9_ZeroMbr,
+        "zfcp": commands.zfcp.F14_ZFCP,
+    }
+
+    dataMap = {
+        "BTRFSData": commands.btrfs.F23_BTRFSData,
+        "DriverDiskData": commands.driverdisk.F14_DriverDiskData,
+        "DeviceData": commands.device.F8_DeviceData,
+        "DmRaidData": commands.dmraid.FC6_DmRaidData,
+        "FcoeData": commands.fcoe.F13_FcoeData,
+        "GroupData": commands.group.F12_GroupData,
+        "IscsiData": commands.iscsi.F17_IscsiData,
+        "LogVolData": commands.logvol.F23_LogVolData,
+        "MountData": commands.mount.F27_MountData,
+        "MultiPathData": commands.multipath.FC6_MultiPathData,
+        "NetworkData": commands.network.F27_NetworkData,
+        "PartData": commands.partition.F23_PartData,
+        "RaidData": commands.raid.F25_RaidData,
+        "RepoData": commands.repo.F27_RepoData,
+        "SnapshotData": commands.snapshot.F26_SnapshotData,
+        "SshPwData": commands.sshpw.F24_SshPwData,
+        "SshKeyData": commands.sshkey.F22_SshKeyData,
+        "UserData": commands.user.F19_UserData,
+        "VolGroupData": commands.volgroup.F21_VolGroupData,
+        "ZFCPData": commands.zfcp.F14_ZFCPData,
+    }

--- a/pykickstart/handlers/rhel7.py
+++ b/pykickstart/handlers/rhel7.py
@@ -34,7 +34,7 @@ class RHEL7Handler(BaseHandler):
         "bootloader": commands.bootloader.RHEL7_Bootloader,
         "btrfs": commands.btrfs.RHEL7_BTRFS,
         "cdrom": commands.cdrom.FC3_Cdrom,
-        "clearpart": commands.clearpart.F21_ClearPart,
+        "clearpart": commands.clearpart.RHEL7_ClearPart,
         "cmdline": commands.displaymode.FC3_DisplayMode,
         "device": commands.device.F8_Device,
         "deviceprobe": commands.deviceprobe.FC3_DeviceProbe,

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -85,9 +85,10 @@ F24 = 22000
 F25 = 23000
 F26 = 24000
 F27 = 25000
+F28 = 26000
 
 # This always points at the latest version and is the default.
-DEVEL = F27
+DEVEL = F28
 
 # A one-to-one mapping from string representations to version numbers.
 versionMap = {
@@ -96,7 +97,7 @@ versionMap = {
     "F9": F9, "F10": F10, "F11": F11, "F12": F12, "F13": F13,
     "F14": F14, "F15": F15, "F16": F16, "F17": F17, "F18": F18,
     "F19": F19, "F20": F20, "F21": F21, "F22": F22, "F23": F23,
-    "F24": F24, "F25": F25, "F26": F26, "F27": F27,
+    "F24": F24, "F25": F25, "F26": F26, "F27": F27, "F28": F28,
     "RHEL3": RHEL3, "RHEL4": RHEL4, "RHEL5": RHEL5, "RHEL6": RHEL6,
     "RHEL7": RHEL7
 }

--- a/tests/commands/clearpart.py
+++ b/tests/commands/clearpart.py
@@ -51,5 +51,22 @@ class F21_TestCase(F17_TestCase):
                           "clearpart --all --initlabel --disklabel=gpt\n")
         self.assert_parse_error("clearpart --all --disklabel")
 
+class F28_TestCase(F21_TestCase):
+    def runTest(self):
+        F21_TestCase.runTest(self)
+        self.assert_parse("clearpart --all --cdl",
+                          "clearpart --all --cdl\n")
+
+        self.assert_parse("clearpart --all --drives=dasda,dasdb,dasdc --cdl",
+                          "clearpart --all --drives=dasda,dasdb,dasdc --cdl\n")
+
+        # cdl should not take a value
+        self.assert_parse_error("clearpart --cdl=foo")
+
+class RHEL7_TestCase(F28_TestCase):
+    def runTest(self):
+        F28_TestCase.runTest(self)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -30,7 +30,7 @@ class WritePriority_TestCase(unittest.TestCase):
                     'selinux', 'skipx', 'mediacheck', 'logging', 'nfs', 'services', 'ignoredisk',
                     'interactive', 'cmdline', 'monitor', 'install', 'shutdown', 'halt',
                     'auth', 'poweroff', 'lilocheck', 'langsupport', 'mouse', 'key',
-                    'unsupported_hardware', 'hmc']:
+                    'unsupported_hardware', 'hmc', 'mount']:
                     self.assertEqual(0, cmd.writePriority, command_class)
                 elif _name in ['bootloader', 'lilo']:
                     self.assertEqual(10, cmd.writePriority, command_class)

--- a/tests/version.py
+++ b/tests/version.py
@@ -117,6 +117,9 @@ class StringToVersion_TestCase(CommandTest):
         # pass - F27
         self.assertEqual(stringToVersion("Fedora 27"), F27)
         self.assertEqual(stringToVersion("F27"), F27)
+        # pass - F28
+        self.assertEqual(stringToVersion("Fedora 28"), F28)
+        self.assertEqual(stringToVersion("F28"), F28)
 
         # pass - RHEL3
         self.assertEqual(stringToVersion("Red Hat Enterprise Linux 3"), RHEL3)
@@ -207,7 +210,8 @@ class VersionToString_TestCase(CommandTest):
         self.assertEqual(versionToString(F25, skipDevel=True), "F25")
         self.assertEqual(versionToString(F26, skipDevel=True), "F26")
         self.assertEqual(versionToString(F27, skipDevel=True), "F27")
-        self.assertEqual(versionToString(F27, skipDevel=False), "DEVEL")
+        self.assertEqual(versionToString(F28, skipDevel=True), "F28")
+        self.assertEqual(versionToString(F28, skipDevel=False), "DEVEL")
         # RHEL series
         self.assertEqual(versionToString(RHEL3), "RHEL3")
         self.assertEqual(versionToString(RHEL4), "RHEL4")


### PR DESCRIPTION
Specifying this option in a ks file will ensure that any LDL DASDs
will be (re)formatted to CDL format.

This option is already supported in RHEL7.

(cherry-picked from commit ec9e128)