### PR TITLE
Commands for specifying base repo are mentioned in docs

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -83,6 +83,10 @@ kickstart file:
    user would be prompted during a typical installation. Once the answer
    is given, the installation will continue unattended unless it finds
    another missing item.
+-  One installation source command from the list of commands in the ``method``
+   proxy command must be specified for the fully automated kickstart
+   installation. This is required even for Fedora -- the closest mirror can't
+   be chosen by the kickstart file.
 -  Lines starting with a pound sign (#) are treated as comments and are
    ignored.
 -  If deprecated commands, options, or syntax are used during a

--- a/pykickstart/commands/method.py
+++ b/pykickstart/commands/method.py
@@ -101,8 +101,12 @@ class FC3_Method(KickstartCommand):
 
     def _getParser(self):
         """Return a parser."""
-        return KSOptionParser(prog="method", description="""
-                            Proxy to the actual installation method.""", version=FC3)
+
+        description = "Proxy to the actual installation method. Valid installation methods are:\n\n"
+        for method in self._methods:
+            description += "* ``%s``\n" % method
+
+        return KSOptionParser(prog="method", description=description, version=FC3)
 
 
 # These are all just for compat.  Calling into the appropriate version-specific


### PR DESCRIPTION
Commands which are required for specifying base repo weren't mentioned in docs. So users can get easily confused that without these commands the closest mirror will be used.