### PR TITLE
master: firewall: add --use-system-defaults arg to command

### DIFF
--- a/pykickstart/commands/firewall.py
+++ b/pykickstart/commands/firewall.py
@@ -17,7 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, F9, F10, F14, F20
+from pykickstart.version import FC3, F9, F10, F14, F20, F28
 from pykickstart.base import KickstartCommand
 from pykickstart.options import ExtendAction, ExtendConstAction, KSOptionParser, commaSplit
 
@@ -240,3 +240,25 @@ class F20_Firewall(F14_Firewall):
             return retval + "%s\n" % svcstr
         else:
             return retval
+
+class F28_Firewall(F20_Firewall):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F20_Firewall.__init__(self, writePriority, *args, **kwargs)
+        self.use_system_defaults = kwargs.get("use_system_defaults", None)
+
+    def _getParser(self):
+        op = F20_Firewall._getParser(self)
+        op.add_argument("--use-system-defaults", dest="use_system_defaults",
+                        action="store_true", default=False, version=F28, help="""
+                        Don't configure the firewall at all. This instructs anaconda
+                        to do nothing and allows the system to rely on the defaults
+                        that were provided with the package or ostree.  If this option
+                        is used with other options then all other options will be
+                        ignored.""")
+        return op
+
+    def __str__(self):
+        if self.use_system_defaults:
+            return "# Firewall configuration\nfirewall --use-system-defaults\n"
+        else:
+            return F20_Firewall.__str__(self)

--- a/pykickstart/handlers/f28.py
+++ b/pykickstart/handlers/f28.py
@@ -42,7 +42,7 @@ class F28Handler(BaseHandler):
         "driverdisk": commands.driverdisk.F14_DriverDisk,
         "eula": commands.eula.F20_Eula,
         "fcoe": commands.fcoe.F13_Fcoe,
-        "firewall": commands.firewall.F20_Firewall,
+        "firewall": commands.firewall.F28_Firewall,
         "firstboot": commands.firstboot.FC3_Firstboot,
         "graphical": commands.displaymode.F26_DisplayMode,
         "group": commands.group.F12_Group,

--- a/tests/commands/firewall.py
+++ b/tests/commands/firewall.py
@@ -20,7 +20,7 @@
 
 import unittest
 from tests.baseclass import CommandTest
-from pykickstart.commands.firewall import FC3_Firewall, F10_Firewall, F20_Firewall
+from pykickstart.commands.firewall import FC3_Firewall, F10_Firewall, F20_Firewall, F28_Firewall
 
 class Firewall_TestCase(unittest.TestCase):
     def runTest(self):
@@ -28,6 +28,7 @@ class Firewall_TestCase(unittest.TestCase):
         self.assertEqual(cmd.__str__(), '')
         self.assertEqual(F10_Firewall().__str__(), '')
         self.assertEqual(F20_Firewall().__str__(), '')
+        self.assertEqual(F28_Firewall().__str__(), '')
 
         op = cmd._getParser()
         for action in op._actions:
@@ -123,6 +124,14 @@ class F20_TestCase(F14_TestCase):
         # multiple remove & remove ssh
         self.assert_parse("firewall --service=mdns --remove-service=dhcpv6-client --remove-service=ssh",
                           "firewall --enabled --service=mdns --remove-service=dhcpv6-client,ssh\n")
+
+class F28_TestCase(F20_TestCase):
+    def runTest(self):
+        F20_TestCase.runTest(self)
+
+        # use-system-defaults
+        self.assert_parse("firewall --use-system-defaults", "firewall --use-system-defaults\n")
+        self.assert_parse("firewall --enabled --service=ssh --use-system-defaults", "firewall --use-system-defaults\n")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Needed for [1] where we would like to include firewalld
and configure firewalld in Atomic Host (in the ostree) and
have Anaconda leave the delivered "defaults" in place.

[1] https://pagure.io/atomic-wg/issue/401