### PR TITLE
pykickstart-2: firewall: add --use-system-defaults arg to command

### DIFF
--- a/pykickstart/commands/firewall.py
+++ b/pykickstart/commands/firewall.py
@@ -233,3 +233,20 @@ class F20_Firewall(F14_Firewall):
             return retval + "%s\n" % svcstr
         else:
             return retval
+
+class F28_Firewall(F20_Firewall):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F20_Firewall.__init__(self, writePriority, *args, **kwargs)
+        self.use_system_defaults = kwargs.get("use_system_defaults", None)
+
+    def _getParser(self):
+        op = F20_Firewall._getParser(self)
+        op.add_option("--use-system-defaults", dest="use_system_defaults",
+                      action="store_true", default=False)
+        return op
+
+    def __str__(self):
+        if self.use_system_defaults:
+            return "# Firewall configuration\nfirewall --use-system-defaults\n"
+        else:
+            return F20_Firewall.__str__(self)

--- a/pykickstart/handlers/f27.py
+++ b/pykickstart/handlers/f27.py
@@ -42,7 +42,7 @@ class F27Handler(BaseHandler):
         "driverdisk": commands.driverdisk.F14_DriverDisk,
         "eula": commands.eula.F20_Eula,
         "fcoe": commands.fcoe.F13_Fcoe,
-        "firewall": commands.firewall.F20_Firewall,
+        "firewall": commands.firewall.F28_Firewall,
         "firstboot": commands.firstboot.FC3_Firstboot,
         "graphical": commands.displaymode.F26_DisplayMode,
         "group": commands.group.F12_Group,

--- a/pykickstart/handlers/f28.py
+++ b/pykickstart/handlers/f28.py
@@ -42,7 +42,7 @@ class F28Handler(BaseHandler):
         "driverdisk": commands.driverdisk.F14_DriverDisk,
         "eula": commands.eula.F20_Eula,
         "fcoe": commands.fcoe.F13_Fcoe,
-        "firewall": commands.firewall.F20_Firewall,
+        "firewall": commands.firewall.F28_Firewall,
         "firstboot": commands.firstboot.FC3_Firstboot,
         "graphical": commands.displaymode.F26_DisplayMode,
         "group": commands.group.F12_Group,

--- a/tests/commands/firewall.py
+++ b/tests/commands/firewall.py
@@ -105,5 +105,13 @@ class F20_TestCase(F14_TestCase):
         self.assert_parse("firewall --service=mdns --remove-service=dhcpv6-client --remove-service=ssh",
                           "firewall --enabled --service=mdns --remove-service=dhcpv6-client,ssh\n")
 
+class F28_TestCase(F20_TestCase):
+    def runTest(self):
+        F20_TestCase.runTest(self)
+
+        # use-system-defaults
+        self.assert_parse("firewall --use-system-defaults", "firewall --use-system-defaults\n")
+        self.assert_parse("firewall --enabled --service=ssh --use-system-defaults", "firewall --use-system-defaults\n")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Needed for [1] where we would like to include firewalld
and configure firewalld in Atomic Host (in the ostree) and
have Anaconda leave the delivered "defaults" in place.

[1] https://pagure.io/atomic-wg/issue/401