### PR TITLE
rhel7-branch: firewall: add --use-system-defaults arg to command

### DIFF
--- a/pykickstart/commands/firewall.py
+++ b/pykickstart/commands/firewall.py
@@ -234,3 +234,20 @@ class F20_Firewall(F14_Firewall):
             return retval + "%s\n" % svcstr
         else:
             return retval
+
+class F28_Firewall(F20_Firewall):
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F20_Firewall.__init__(self, writePriority, *args, **kwargs)
+        self.use_system_defaults = kwargs.get("use_system_defaults", None)
+
+    def _getParser(self):
+        op = F20_Firewall._getParser(self)
+        op.add_option("--use-system-defaults", dest="use_system_defaults",
+                      action="store_true", default=False)
+        return op
+
+    def __str__(self):
+        if self.use_system_defaults:
+            return "# Firewall configuration\nfirewall --use-system-defaults\n"
+        else:
+            return F20_Firewall.__str__(self)

--- a/pykickstart/handlers/rhel7.py
+++ b/pykickstart/handlers/rhel7.py
@@ -42,7 +42,7 @@ class RHEL7Handler(BaseHandler):
         "driverdisk": commands.driverdisk.F14_DriverDisk,
         "eula": commands.eula.F20_Eula,
         "fcoe": commands.fcoe.RHEL7_Fcoe,
-        "firewall": commands.firewall.F20_Firewall,
+        "firewall": commands.firewall.F28_Firewall,
         "firstboot": commands.firstboot.FC3_Firstboot,
         "graphical": commands.displaymode.FC3_DisplayMode,
         "group": commands.group.F12_Group,


### PR DESCRIPTION
Needed for [1] where we would like to include firewalld
and configure firewalld in Atomic Host (in the ostree) and
have Anaconda leave the delivered "defaults" in place.

[1] https://pagure.io/atomic-wg/issue/401

(cherry picked from commit 6c2ac9500dcfc9c32e1bd329f1a0a16e8c02043b)