### PR TITLE
Copy txt files from _build folder on make local call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ archive: check test tag docs
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 local: docs po-pull
+	cp docs/_build/text/*.txt docs/
 	@$(PYTHON) setup.py -q sdist --dist-dir .
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 


### PR DESCRIPTION
Without this you won't be able to do a build with make local because `kickstart-docs.txt` file is used to create an rpm but expected in docs folder and not in `docs/_build` folder.